### PR TITLE
Add indexes to tagged_items table

### DIFF
--- a/app/database/migrations/2015_04_12_172949_add_indexes_to_tagged_items.php
+++ b/app/database/migrations/2015_04_12_172949_add_indexes_to_tagged_items.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexesToTaggedItems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tagged_items', function (Blueprint $table) {
+            $table->index('thread_id');
+            $table->index('tag_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tagged_items', function (Blueprint $table) {
+            $table->dropIndex(['thread_id']);
+            $table->dropIndex(['tag_id']);
+        });
+   }
+}


### PR DESCRIPTION
Should help with load speed of forum "categories", a.k.a. tagged threads.