### PR TITLE
Register missing hashids alias

### DIFF
--- a/app/Lio/ServiceProviders/HashidsServiceProvider.php
+++ b/app/Lio/ServiceProviders/HashidsServiceProvider.php
@@ -7,7 +7,7 @@ class HashidsServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->app->bind('Hashids\Hashids', function() {
+        $this->app->bind(['Hashids\Hashids' => 'hashids'], function() {
             $key = $this->app['config']->get('app.key');
             return new Hashids($key, 2);
         });


### PR DESCRIPTION
The service provider pretends to provide an `hashids` alias but this alias is never registered anywhere. This commit fixes this.