### PR TITLE
Move Hashids binding to register method & fix alias

### DIFF
--- a/app/Lio/ServiceProviders/HashidsServiceProvider.php
+++ b/app/Lio/ServiceProviders/HashidsServiceProvider.php
@@ -5,15 +5,11 @@ use Hashids\Hashids;
 
 class HashidsServiceProvider extends ServiceProvider
 {
-    public function boot()
+    public function register() 
     {
-        $this->app->bind('Hashids\Hashids', function() {
+        $this->app->bind(['Hashids\Hashids' => 'hashids'], function() {
             $key = $this->app['config']->get('app.key');
             return new Hashids($key, 2);
         });
-    }
-
-    public function register() {
-        return ['hashids'];
     }
 }

--- a/app/Lio/ServiceProviders/HashidsServiceProvider.php
+++ b/app/Lio/ServiceProviders/HashidsServiceProvider.php
@@ -7,8 +7,9 @@ class HashidsServiceProvider extends ServiceProvider
 {
     public function register() 
     {
-        $this->app->bind(['Hashids\Hashids' => 'hashids'], function() {
-            $key = $this->app['config']->get('app.key');
+        $this->app->bind(['Hashids\Hashids' => 'hashids'], function($app) {
+            $key = $app['config']->get('app.key');
+            
             return new Hashids($key, 2);
         });
     }


### PR DESCRIPTION
As discussed in #217, the `register()` method is more appropriate than `boot()` to register bindings with the container. This change also fixes the registration of the `hashids` alias.