### PR TITLE
Prevent duplicate query in notifications component

### DIFF
--- a/app/Http/Livewire/Notifications.php
+++ b/app/Http/Livewire/Notifications.php
@@ -3,7 +3,6 @@
 namespace App\Http\Livewire;
 
 use App\Policies\NotificationPolicy;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Auth;

--- a/app/Http/Livewire/Notifications.php
+++ b/app/Http/Livewire/Notifications.php
@@ -34,7 +34,7 @@ final class Notifications extends Component
         return DatabaseNotification::findOrFail($this->notificationId);
     }
 
-    public function markAsRead(string $notificationId): LengthAwarePaginator
+    public function markAsRead(string $notificationId): void
     {
         $this->notificationId = $notificationId;
 
@@ -42,10 +42,6 @@ final class Notifications extends Component
 
         $this->notification->markAsRead();
 
-        $unreadNotifications = Auth::user()->unreadNotifications()->paginate(10);
-
-        $this->emit('NotificationMarkedAsRead', $unreadNotifications->total());
-
-        return $unreadNotifications;
+        $this->emit('NotificationMarkedAsRead', Auth::user()->unreadNotifications()->count());
     }
 }


### PR DESCRIPTION
There is no need to return the unread notification count as the component will re-render after the notification is marked as read.