### PR TITLE
Fix tag misalignment due to solution button

### DIFF
--- a/resources/views/forum/threads/_view_solution.blade.php
+++ b/resources/views/forum/threads/_view_solution.blade.php
@@ -1,5 +1,5 @@
 @if ($thread->isSolved())
-    <a class="label label-primary text-center mt-4 md:mt-0"
+    <a class="label label-primary text-center mt-4 sm:mt-0"
        href="{{ route('thread', $thread->slug()) }}#{{ $thread->solution_reply_id }}">
         <i class="fa fa-check mr-2"></i>
         View solution

--- a/resources/views/forum/threads/show.blade.php
+++ b/resources/views/forum/threads/show.blade.php
@@ -16,7 +16,7 @@
             <div class="w-full md:w-3/4 md:pr-3">
                 <div class="reply bg-white border rounded">
                     <div class="flex flex-col md:flex-row md:items-center text-sm p-4 border-b">
-                        <div class="flex flex-wrap mb-4 md:mb-0 justify-between w-full items-center">
+                        <div class="flex flex-col flex-wrap flex-1 justify-between md:flex-row md:items-center mb-4 md:mb-0 md:mr-2">
                             <div class="flex">
                                 @include('forum.threads.info.avatar', ['user' => $thread->author()])
 
@@ -28,10 +28,13 @@
                                 </div>
                             </div>
 
-                            @include('forum.threads._view_solution')
+                            <div class="flex flex-col items-start sm:flex-row sm:items-center">
+                                <div class="mr-2">
+                                    @include('forum.threads.info.tags')
+                                </div>
+                                @include('forum.threads._view_solution')
+                            </div>
                         </div>
-
-                        @include('forum.threads.info.tags')
                     </div>
                     <div class="p-4">
                         <div 


### PR DESCRIPTION
Closes #495 . Sorry for the problem I caused here, completely forgot tags existed since I didn't have any on my test thread.

Here's a screenshot of what they look like now:

![image](https://user-images.githubusercontent.com/41837763/76458105-efc1ed80-63d1-11ea-8951-762f62689a14.png)

I've moved the solution button to the end too. On mobile, the tags will be directly below the title and the solution button underneath them.