### PR TITLE
Format the article editor

### DIFF
--- a/app/Http/Controllers/Articles/ArticlesController.php
+++ b/app/Http/Controllers/Articles/ArticlesController.php
@@ -35,13 +35,15 @@ class ArticlesController extends Controller
     public function create()
     {
         $tags = Tag::all();
-        $selectedTags = old('tags') ?: [];
+        $selectedTags = old('tags', []);
         $series = Series::all();
+        $selectedSeries = old('series');
 
         return view('articles.create', [
             'tags' => $tags,
             'selectedTags' => $selectedTags,
             'series' => $series,
+            'selectedSeries' => $selectedSeries,
         ]);
     }
 
@@ -57,14 +59,17 @@ class ArticlesController extends Controller
     public function edit(Article $article)
     {
         $this->authorize(ArticlePolicy::UPDATE, $article);
-        $selectedTags = $article->tags()->pluck('id')->toArray();
+
+        $selectedTags = old('tags', $article->tags()->pluck('id')->toArray());
         $series = Series::all();
+        $selectedSeries = old('series', $article->series->id);
 
         return view('articles.edit', [
             'article' => $article,
             'tags' => Tag::all(),
             'selectedTags' => $selectedTags,
             'series' => $series,
+            'selectedSeries' => $selectedSeries,
         ]);
     }
 

--- a/app/Http/Controllers/Articles/SeriesController.php
+++ b/app/Http/Controllers/Articles/SeriesController.php
@@ -49,7 +49,7 @@ class SeriesController extends Controller
     {
         $this->authorize(SeriesPolicy::UPDATE, $series);
 
-        $selectedTags = $series->tags()->pluck('id')->toArray();
+        $selectedTags = old('tags', $series->tags()->pluck('id')->toArray());
 
         return view('series.edit', ['series' => $series, 'tags' => Tag::all(), 'selectedTags' => $selectedTags]);
     }

--- a/app/Http/Requests/ArticleRequest.php
+++ b/app/Http/Requests/ArticleRequest.php
@@ -12,10 +12,10 @@ class ArticleRequest extends Request
         return [
             'title' => ['required', 'max:100'],
             'body' => ['required', new HttpImageRule],
-            'tags' => 'array',
+            'tags' => 'array|nullable',
             'tags.*' => 'exists:tags,id',
-            'series' => 'exists:series,id',
-            'original_url' => 'url',
+            'series' => 'exists:series,id|nullable',
+            'original_url' => 'url|nullable',
         ];
     }
 

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -38,9 +38,14 @@ final class Article extends Model
         return $this->body;
     }
 
-    public function originalUrl(): string
+    public function originalUrl(): ?string
     {
-        return $this->original_url ?: route('articles.show', $this->slug);
+        return $this->original_url;
+    }
+
+    public function canonicalUrl(): string
+    {
+        return $this->originalUrl() ?: route('articles.show', $this->slug);
     }
 
     public function series()

--- a/resources/css/forms.css
+++ b/resources/css/forms.css
@@ -8,10 +8,20 @@ label {
 
 input[type=text],
 input[type=password],
+input[type=email] {
+    @apply h-12;
+}
+
+input[type=text],
+input[type=password],
 input[type=email],
 textarea,
 select {
-    @apply rounded border-2 p-3 w-full appearance-none;
+    @apply rounded border-2 p-3 w-full;
+}
+
+select {
+    @apply appearance-none;
 }
 
 input.nav-search {
@@ -27,6 +37,10 @@ input[type=checkbox] {
 }
 
 /** Markdown editor **/
+.form-group .editor {
+    @apply rounded-t-none;
+}
+
 .form-group .editor-toolbar {
     @apply border-2 border-b-0 rounded rounded-b-none border-gray-300;
 }
@@ -40,8 +54,24 @@ input[type=checkbox] {
     @apply hidden;
 }
 
+.choices__inner {
+    @apply rounded border-2 border-gray-300 w-full bg-white h-12 p-2 flex items-center !important;
+}
+
+.choices__list--dropdown {
+    @apply border-2 border-gray-300 !important;
+}
+
+.choices__list--single {
+    @apply p-0 !important;
+}
+
 .choices__item {
-    @apply text-xs uppercase bg-gray-200 text-gray-700 cursor-pointer rounded px-2 py-1 !important;
+    @apply text-sm bg-gray-200 text-gray-700 cursor-pointer rounded px-2 py-1 my-0 border-0 !important;
+}
+
+.choices__item.choices__item--choice {
+    @apply rounded-none py-2 !important;
 }
 
 .choices__item.choices__item--choice.choices__item--selectable {
@@ -56,6 +86,18 @@ input[type=checkbox] {
     @apply bg-green-primary border-green-primary text-white !important;
 }
 
+.choices__list--single > .choices__item.choices__item--selectable {
+    @apply bg-white text-gray-700 !important;
+}
+
 .choices__item.is-highlighted {
     @apply bg-green-dark border-green-dark text-white !important;
+}
+
+.choices[data-type*='select-one']:after {
+    border-color: theme('colors.gray.500') transparent transparent transparent !important;
+}
+
+.choices[data-type*='select-one'] .choices__input {
+    @apply rounded-none border-b-2 border-gray-300 !important;
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,6 +9,7 @@ import "choices.js/public/assets/styles/choices.css";
 
 require('./bootstrap');
 require('./search');
+require('./editor');
 
 // Initialise cookie consent.
 document.addEventListener('DOMContentLoaded', () => {
@@ -29,113 +30,16 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // Create a multiselect element.
-window.choices = (element) => { return new Choices(element, { maxItemCount: 3, removeItemButton: true }) };
+window.choices = (element) => {
+    return new Choices(element, {
+        maxItemCount: 3,
+        removeItemButton: true
+    })
+};
 
 // Syntax highlight code blocks.
 window.highlightCode = (element) => {
     element.querySelectorAll("pre code").forEach(block => {
         hljs.highlightBlock(block);
     });
-}
-
-// Handle the click event of the style buttons inside the editor.
-window.handleClick = (style, element) => {
-    const { styles } = editorConfig();
-    const input = element.querySelectorAll("textarea")[0];
-
-    // Get the start and end positions of the current selection.
-    const selectionStart = input.selectionStart;
-    const selectionEnd = input.selectionEnd;
-
-    // Find the style in the configuration.
-    const styleFormat = styles[style];
-
-    // Get any prefix and/or suffix characters from the selected style.
-    const prefix = styleFormat.before ? styleFormat.before : "";
-    const suffix = styleFormat.after ? styleFormat.after : "";
-
-    // Insert the prefix at the relevant position.
-    input.value = insertCharactersAtPosition(
-        input.value,
-        prefix,
-        selectionStart
-    );
-
-    // Insert the suffix at the relevant position.
-    input.value = insertCharactersAtPosition(
-        input.value,
-        suffix,
-        selectionEnd + prefix.length
-    );
-
-    // Reselect the selection and focus the input.
-    input.setSelectionRange(
-        selectionStart + prefix.length,
-        selectionEnd + prefix.length
-    );
-    input.focus();
-}
-
-// Insert provided characters at the desired place in a string.
-const insertCharactersAtPosition = (string, character, position) => {
-    return [
-        string.slice(0, position),
-        character,
-        string.slice(position)
-    ].join("");
-}
-
-// Configuration object for the text editor.
-window.editorConfig = () => {
-    return {
-        styles: {
-            header: {
-                before: "### ",
-                class: {
-                    "fa-header": true
-                }
-            },
-            bold: {
-                before: "**",
-                after: "**",
-                class: {
-                    "fa-bold": true
-                }
-            },
-            italic: {
-                before: "_",
-                after: "_",
-                class: {
-                    "fa-italic": true
-                }
-            },
-            quote: {
-                before: "> ",
-                class: {
-                    "fa-quote-left": true
-                }
-            },
-            code: {
-                before: "`",
-                after: "`",
-                class: {
-                    "fa-code": true
-                }
-            },
-            link: {
-                before: "[](",
-                after: ")",
-                class: {
-                    "fa-link": true
-                }
-            },
-            image: {
-                before: "![](",
-                after: ")",
-                class: {
-                    "fa-file-image-o": true
-                }
-            }
-        }
-    }
 }

--- a/resources/views/_partials/_editor.blade.php
+++ b/resources/views/_partials/_editor.blade.php
@@ -1,4 +1,4 @@
-<div x-data="editorConfig()">
+<div x-data="editorConfig()" x-init="minHeight = $refs.editor.scrollHeight">
     <div class="border-2 border-b-0 rounded-t p-2 bg-gray-200">
         <ul>
             <li>
@@ -18,8 +18,10 @@
         </ul>
     </div>
     <textarea
+        @keyup="expand(event, minHeight)"
+        x-ref="editor"
         name="body"
         id="body"
-        class="editor rounded-t-none resize-none h-40"
+        class="editor rounded-t-none resize-none h-40 focus:outline-none"
     >{{ old('body') ?: $content }}</textarea>
 </div>

--- a/resources/views/articles/_form.blade.php
+++ b/resources/views/articles/_form.blade.php
@@ -1,73 +1,86 @@
-<form action="{{ route(...$route) }}" method="POST">
+<form action="{{ route(...$route) }}" method="POST" x-data="{ showAdvanced: false }">
     @csrf
     @method($method ?? 'POST')
 
-    @formGroup('title')
-        <label for="title">Title</label>
-        <input 
-            type="text" 
-            name="title" 
-            id="title" 
-            value="{{ isset($article) ? $article->title() : null }}" 
-            class="form-control" 
-            required maxlength="60" 
-        />
-        <span class="text-gray-600 text-sm">Maximum 60 characters.</span>
-        @error('title')
-    @endFormGroup
+    <div class="px-4 pt-4">
+        @formGroup('title')
+            <label for="title">Title</label>
+            <input 
+                type="text" 
+                name="title" 
+                id="title" 
+                value="{{ old('title', isset($article) ? $article->title() : null) }}" 
+                class="form-control" 
+                required maxlength="100" 
+            />
+            <span class="text-gray-600 text-sm mt-1">Maximum 100 characters.</span>
+            @error('title')
+        @endFormGroup
 
-    @formGroup('body')
-        <label for="body">Body</label>
+        @formGroup('body')
+            <label for="body">Body</label>
 
-        @include('_partials._editor', [
-            'content' => isset($article) ? $article->body() : null
-        ])
-        
-        @error('body')
-    @endFormGroup
+            @include('_partials._editor', [
+                'content' => isset($article) ? $article->body() : null
+            ])
+            
+            @error('body')
+        @endFormGroup
+    </div>
 
-    @formGroup('original_url')
-        <label for="original_url">Original URL</label>
-        <input 
-            type="text" 
-            name="original_url" 
-            id="original_url" 
-            value="{{ isset($article) ? $article->originalUrl() : null }}" 
-            class="form-control"
-        />
-        <span class="text-gray-600 text-sm">If you have already posted this article on your own site, enter the URL here and the content will be attributed to you.</span>
-        @error('original_url')
-    @endFormGroup
+    <div x-show="showAdvanced" x-cloak class="px-4 pt-4 border-t-2">
+        @formGroup('original_url')
+            <label for="original_url">Original URL</label>
+            <input 
+                type="text" 
+                name="original_url" 
+                id="original_url" 
+                value="{{ old('original_url', isset($article) ? $article->originalUrl() : null) }}" 
+                class="form-control" 
+            />
+            <span class="text-gray-600 text-sm mt-1">If you have already posted this article on your own site, enter the URL here and the content will be attributed to you.</span>
+            @error('original_url')
+        @endFormGroup
 
-    @formGroup('tags')
-        <label for="tags">Tags</label>
+        @formGroup('tags')
+            <label for="tags">Tags</label>
 
-        <select name="tags[]" id="create-article" multiple x-data="{}" x-init="function () { choices($el) }">
-            @foreach($tags as $tag)
-                <option value="{{ $tag->id }}" @if(in_array($tag->id, $selectedTags)) selected @endif>{{ $tag->name }}</option>
-            @endforeach
-        </select>
-
-        @error('tags')
-    @endFormGroup
-
-    @if($series->count() > 0)
-        @formGroup('series')
-            <label for="series">Series</label>
-
-            <select name="series">
-                <option value="">Select a series</option>
-                @foreach($series as $s)
-                    <option value="{{ $s->id }}" @if(isset($article) && $article->series_id === $s->id) selected @endif>{{ $s->title }}</option>
+            <select name="tags[]" id="create-article" multiple x-data="{}" x-init="function () { choices($el) }">
+                @foreach($tags as $tag)
+                    <option value="{{ $tag->id }}" @if(in_array($tag->id, $selectedTags)) selected @endif>{{ $tag->name }}</option>
                 @endforeach
             </select>
 
             @error('tags')
         @endFormGroup
-    @endif
 
-    <div class="flex justify-end items-center">
-        <a href="{{ isset($article) ? route('articles.show', $article->slug()) : route('articles') }}" class="text-green-darker mr-4">Cancel</a>
-        <button type="submit" class="button button-primary">{{ isset($article) ? 'Update Article' : 'Create Article' }}</button>
+        @if($series->count() > 0)
+            @formGroup('series')
+                <label for="series">Series</label>
+
+                <select name="series" x-data="{}" x-init="function () { choices($el) }">
+                    <option value="">Select a series</option>
+                    @foreach($series as $s)
+                        <option value="{{ $s->id }}" @if($selectedSeries == $s->id) selected @endif>{{ $s->title }}</option>
+                    @endforeach
+                </select>
+
+                @error('tags')
+            @endFormGroup
+        @endif
+    </div>
+
+    <div class="px-4 pb-4">
+        <button 
+            type="button" 
+            class="text-green-darker" 
+            @click="showAdvanced = !showAdvanced" 
+            x-text="showAdvanced ? 'Hide advanced options' : 'Show advanced options'"
+        ></button>
+
+        <div class="flex justify-end items-center">
+            <a href="{{ isset($article) ? route('articles.show', $article->slug()) : route('articles') }}" class="text-green-darker mr-4">Cancel</a>
+            <button type="submit" class="button button-primary">{{ isset($article) ? 'Update Article' : 'Create Article' }}</button>
+        </div>
     </div>
 </form>

--- a/resources/views/articles/create.blade.php
+++ b/resources/views/articles/create.blade.php
@@ -5,7 +5,7 @@
 @section('content')
     <div class="container mx-auto p-4 flex justify-center">
         <div class="w-full md:w-2/3 xl:w-1/2">
-            <div class="md:p-4 md:border-2 md:rounded md:bg-gray-100">
+            <div class="md:border-2 md:rounded md:bg-gray-100">
                 @include('articles._form', [
                     'route' => ['articles.store'],
                 ])

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.default')
 
 @push('meta')
-<link rel="canonical" href="{{ $article->originalUrl() }}" />
+<link rel="canonical" href="{{ $article->canonicalUrl() }}" />
 @endpush
 
 @section('content')

--- a/resources/views/series/_form.blade.php
+++ b/resources/views/series/_form.blade.php
@@ -8,11 +8,11 @@
             type="text" 
             name="title" 
             id="title" 
-            value="{{ isset($series) ? $series->title() : null }}" 
+            value="{{ old('title', isset($series) ? $series->title() : null) }}" 
             class="form-control" 
-            required maxlength="60" 
+            required maxlength="100" 
         />
-        <span class="text-gray-600 text-sm">Maximum 60 characters.</span>
+        <span class="text-gray-600 text-sm mt-1">Maximum 100 characters.</span>
         @error('title')
     @endFormGroup
 

--- a/tests/Integration/Jobs/CreateArticleTest.php
+++ b/tests/Integration/Jobs/CreateArticleTest.php
@@ -20,7 +20,7 @@ class CreateArticleTest extends TestCase
 
         $this->assertEquals('Title', $article->title());
         $this->assertEquals('Body', $article->body());
-        $this->assertEquals('https://laravel.io', $article->originalUrl());
+        $this->assertEquals('https://laravel.io', $article->canonicalUrl());
     }
 
     /** @test */
@@ -36,7 +36,7 @@ class CreateArticleTest extends TestCase
 
         $this->assertEquals('Title', $article->title());
         $this->assertEquals('Body', $article->body());
-        $this->assertEquals('https://laravel.io', $article->originalUrl());
+        $this->assertEquals('https://laravel.io', $article->canonicalUrl());
         $this->assertEquals($series->id, $article->id());
     }
 }

--- a/tests/Integration/Jobs/UpdateArticleTest.php
+++ b/tests/Integration/Jobs/UpdateArticleTest.php
@@ -38,7 +38,7 @@ class UpdateArticleTest extends TestCase
 
         $this->assertEquals('Title', $article->title());
         $this->assertEquals('Body', $article->body());
-        $this->assertEquals('https://laravel.io', $article->originalUrl());
+        $this->assertEquals('https://laravel.io', $article->canonicalUrl());
         $this->assertEquals($series->id, $article->id());
     }
 


### PR DESCRIPTION
This PR makes some subtle changes to inputs and styles:

- Fields repopulate correctly when form validation fails
- Choices select/multi-select field styled more consistently with the rest of the UI
- Markdown editor increases in size as the user types

<img width="1123" alt="Screenshot 2020-04-19 at 16 04 13" src="https://user-images.githubusercontent.com/3438564/79691453-80081380-8257-11ea-948b-1e6f229e7de5.png">

<img width="1147" alt="Screenshot 2020-04-19 at 15 39 12" src="https://user-images.githubusercontent.com/3438564/79691429-564eec80-8257-11ea-94f1-c2c3c9aa2b05.png">
