### PR TITLE
Add support for draft and published articles

### DIFF
--- a/app/Http/Controllers/Articles/ArticlesController.php
+++ b/app/Http/Controllers/Articles/ArticlesController.php
@@ -32,7 +32,7 @@ class ArticlesController extends Controller
             $article->isPublished() || (Auth::check() && $article->isAuthoredBy(Auth::user())),
             404
         );
-        
+
         return view('articles.show', [
             'article' => $article,
         ]);

--- a/app/Http/Controllers/Articles/ArticlesController.php
+++ b/app/Http/Controllers/Articles/ArticlesController.php
@@ -13,6 +13,7 @@ use App\Models\Article;
 use App\Models\Tag;
 use App\Policies\ArticlePolicy;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class ArticlesController extends Controller
 {
@@ -27,9 +28,13 @@ class ArticlesController extends Controller
 
     public function show(Article $article)
     {
-        return view('articles.show', [
-            'article' => $article,
-        ]);
+        if ($article->isPublished() || (Auth::check() && $article->isAuthoredBy(Auth::user()))) {
+            return view('articles.show', [
+                'article' => $article,
+            ]);
+        }
+
+        abort(404);
     }
 
     public function create(Request $request)

--- a/app/Http/Controllers/Articles/ArticlesController.php
+++ b/app/Http/Controllers/Articles/ArticlesController.php
@@ -28,13 +28,14 @@ class ArticlesController extends Controller
 
     public function show(Article $article)
     {
-        if ($article->isPublished() || (Auth::check() && $article->isAuthoredBy(Auth::user()))) {
-            return view('articles.show', [
-                'article' => $article,
-            ]);
-        }
-
-        abort(404);
+        abort_unless(
+            $article->isPublished() || (Auth::check() && $article->isAuthoredBy(Auth::user())),
+            404
+        );
+        
+        return view('articles.show', [
+            'article' => $article,
+        ]);
     }
 
     public function create(Request $request)

--- a/app/Http/Requests/ArticleRequest.php
+++ b/app/Http/Requests/ArticleRequest.php
@@ -5,9 +5,12 @@ namespace App\Http\Requests;
 use App\Rules\AuthorOwnsSeriesRule;
 use App\Rules\HttpImageRule;
 use App\User;
+use Illuminate\Http\Concerns\InteractsWithInput;
 
 class ArticleRequest extends Request
 {
+    use InteractsWithInput;
+
     public function rules()
     {
         return [
@@ -17,7 +20,7 @@ class ArticleRequest extends Request
             'tags.*' => 'exists:tags,id',
             'original_url' => 'url|nullable',
             'series' => ['nullable', new AuthorOwnsSeriesRule],
-            'status' => ['required', 'in:draft,publish'],
+            'published' => ['required', 'boolean'],
         ];
     }
 
@@ -53,6 +56,6 @@ class ArticleRequest extends Request
 
     public function shouldBePublished(): bool
     {
-        return $this->get('status') === 'publish';
+        return $this->boolean('published');
     }
 }

--- a/app/Http/Requests/ArticleRequest.php
+++ b/app/Http/Requests/ArticleRequest.php
@@ -17,6 +17,7 @@ class ArticleRequest extends Request
             'tags.*' => 'exists:tags,id',
             'original_url' => 'url|nullable',
             'series' => ['nullable', new AuthorOwnsSeriesRule],
+            'status' => ['required', 'in:draft,publish'],
         ];
     }
 
@@ -48,5 +49,10 @@ class ArticleRequest extends Request
     public function originalUrl(): ?string
     {
         return $this->get('original_url');
+    }
+
+    public function shouldBePublished(): bool
+    {
+        return $this->get('status') === 'publish';
     }
 }

--- a/app/Jobs/CreateArticle.php
+++ b/app/Jobs/CreateArticle.php
@@ -15,17 +15,20 @@ final class CreateArticle
 
     private $author;
 
+    private $shouldBePublished;
+
     private $originalUrl;
 
     private $tags;
 
     private $series;
 
-    public function __construct(string $title, string $body, User $author, array $options = [])
+    public function __construct(string $title, string $body, User $author, bool $shouldBePublished, array $options = [])
     {
         $this->title = $title;
         $this->body = $body;
         $this->author = $author;
+        $this->shouldBePublished = $shouldBePublished;
         $this->originalUrl = $options['original_url'] ?? null;
         $this->tags = $options['tags'] ?? [];
         $this->series = $options['series'] ?? null;
@@ -37,6 +40,7 @@ final class CreateArticle
             $request->title(),
             $request->body(),
             $request->author(),
+            $request->shouldBePublished(),
             [
                 'original_url' => $request->originalUrl(),
                 'tags' => $request->tags(),
@@ -52,6 +56,7 @@ final class CreateArticle
             'body' => $this->body,
             'original_url' => $this->originalUrl,
             'slug' => $this->title,
+            'published_at' => $this->shouldBePublished ? now() : null,
         ]);
         $article->authoredBy($this->author);
         $article->syncTags($this->tags);

--- a/app/Jobs/UpdateArticle.php
+++ b/app/Jobs/UpdateArticle.php
@@ -14,17 +14,20 @@ final class UpdateArticle
 
     private $body;
 
+    private $shouldBePublished;
+
     private $originalUrl;
 
     private $tags;
 
     private $series;
 
-    public function __construct(Article $article, string $title, string $body, array $options = [])
+    public function __construct(Article $article, string $title, string $body, bool $shouldBePublished, array $options = [])
     {
         $this->article = $article;
         $this->title = $title;
         $this->body = $body;
+        $this->shouldBePublished = $shouldBePublished;
         $this->originalUrl = $options['original_url'] ?? null;
         $this->tags = $options['tags'] ?? [];
         $this->series = $options['series'] ?? null;
@@ -36,6 +39,7 @@ final class UpdateArticle
             $article,
             $request->title(),
             $request->body(),
+            $request->shouldBePublished(),
             [
                 'original_url' => $request->originalUrl(),
                 'tags' => $request->tags(),
@@ -51,6 +55,7 @@ final class UpdateArticle
             'body' => $this->body,
             'original_url' => $this->originalUrl,
             'slug' => $this->title,
+            'published_at' => $this->shouldBePublished ? now() : null,
         ]);
         $this->article->syncTags($this->tags);
         $this->article->updateSeries(Series::find($this->series));

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -7,6 +7,8 @@ use App\Helpers\HasLikes;
 use App\Helpers\HasSlug;
 use App\Helpers\HasTags;
 use App\Helpers\HasTimestamps;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 final class Article extends Model
@@ -21,6 +23,14 @@ final class Article extends Model
         'body',
         'original_url',
         'slug',
+        'published_at',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $dates = [
+        'published_at',
     ];
 
     public function id(): int
@@ -76,5 +86,30 @@ final class Article extends Model
         $this->save();
 
         return $this;
+    }
+
+    public function publishedAt(): ?Carbon
+    {
+        return $this->published_at;
+    }
+
+    public function isPublished(): bool
+    {
+        return ! $this->isNotPublished();
+    }
+
+    public function isNotPublished(): bool
+    {
+        return is_null($this->published_at);
+    }
+
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query->whereNotNull('published_at');
+    }
+
+    public function scopeNotPublished(Builder $query): Builder
+    {
+        return $query->whereNull('published_at');
     }
 }

--- a/database/migrations/2020_04_07_185543_create_community_articles_table.php
+++ b/database/migrations/2020_04_07_185543_create_community_articles_table.php
@@ -16,6 +16,7 @@ class CreateCommunityArticlesTable extends Migration
             $table->text('body');
             $table->string('original_url')->nullable();
             $table->string('slug')->unique();
+            $table->timestamp('published_at')->nullable();
             $table->timestamps();
 
             $table->foreign('series_id')

--- a/resources/css/buttons.css
+++ b/resources/css/buttons.css
@@ -49,3 +49,11 @@
 a.button:hover {
     @apply no-underline;
 }
+
+.button-dropdown-left {
+    @apply rounded-r-none px-2;
+}
+
+.button-dropdown-right {
+    @apply rounded-l-none px-2;
+}

--- a/resources/views/articles/_form.blade.php
+++ b/resources/views/articles/_form.blade.php
@@ -80,11 +80,11 @@
 
         <div class="flex justify-end items-center">
             <a href="{{ isset($article) ? route('articles.show', $article->slug()) : route('articles') }}" class="text-green-darker mr-4">Cancel</a>
-            @if(isset($article) && $article->isPublished())
+            @if (isset($article) && $article->isPublished())
                 <button 
                     type="submit" 
-                    name="status" 
-                    value="publish" 
+                    name="published" 
+                    value="1" 
                     class="button button-primary"
                 >
                     Save changes
@@ -93,8 +93,8 @@
                 <span class="relative z-0 inline-flex shadow-sm" x-data="{ showDropdown: false }" @click.away="showDropdown = false">
                     <button 
                         type="submit" 
-                        name="status" 
-                        value="draft" 
+                        name="published" 
+                        value="0" 
                         class="button button-primary button-dropdown-left relative inline-flex items-center focus:outline-none"
                     >
                         Save draft
@@ -114,8 +114,8 @@
                                 <div class="py-1">
                                     <button 
                                         type="submit" 
-                                        name="status" 
-                                        value="publish" 
+                                        name="published" 
+                                        value="1" 
                                         class="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900 w-full text-left"
                                     >
                                         Save and publish

--- a/resources/views/articles/_form.blade.php
+++ b/resources/views/articles/_form.blade.php
@@ -80,7 +80,52 @@
 
         <div class="flex justify-end items-center">
             <a href="{{ isset($article) ? route('articles.show', $article->slug()) : route('articles') }}" class="text-green-darker mr-4">Cancel</a>
-            <button type="submit" class="button button-primary">{{ isset($article) ? 'Update Article' : 'Create Article' }}</button>
+            @if(isset($article) && $article->isPublished())
+                <button 
+                    type="submit" 
+                    name="status" 
+                    value="publish" 
+                    class="button button-primary"
+                >
+                    Save changes
+                </button>
+            @else
+                <span class="relative z-0 inline-flex shadow-sm" x-data="{ showDropdown: false }" @click.away="showDropdown = false">
+                    <button 
+                        type="submit" 
+                        name="status" 
+                        value="draft" 
+                        class="button button-primary button-dropdown-left relative inline-flex items-center focus:outline-none"
+                    >
+                        Save draft
+                    </button>
+                    <span class="-ml-px relative block">
+                        <button 
+                            @click="showDropdown = !showDropdown" 
+                            type="button" 
+                            class="button button-primary h-full button-dropdown-right relative inline-flex items-center focus:outline-none"
+                        >
+                            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
+                            </svg>
+                        </button>
+                        <div class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg" x-show="showDropdown" x-cloak>
+                            <div class="rounded-md bg-white shadow-xs">
+                                <div class="py-1">
+                                    <button 
+                                        type="submit" 
+                                        name="status" 
+                                        value="publish" 
+                                        class="block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900 w-full text-left"
+                                    >
+                                        Save and publish
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </span>
+                </span>
+            @endif
         </div>
     </div>
 </form>

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -7,7 +7,7 @@
 @section('content')
     <div class="max-w-screen-md mx-auto p-4 pt-8">
         <h1 class="text-4xl tracking-tight leading-10 font-extrabold text-gray-900 sm:leading-none mb-4">{{ $article->title() }}</h1>
-        @if($article->isNotPublished())
+        @if ($article->isNotPublished())
             <span class="label inline-flex mb-4">
                 Draft
             </span>

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -7,12 +7,17 @@
 @section('content')
     <div class="max-w-screen-md mx-auto p-4 pt-8">
         <h1 class="text-4xl tracking-tight leading-10 font-extrabold text-gray-900 sm:leading-none mb-4">{{ $article->title() }}</h1>
+        @if($article->isNotPublished())
+            <span class="label inline-flex mb-4">
+                Draft
+            </span>
+        @endif
         <div class="mr-6 mb-8 text-gray-700 flex items-center">
             @include('forum.threads.info.avatar', ['user' => $article->author(), 'size' => 50])
             <div>
                 <a href="{{ route('profile', $article->author()->username()) }}"
                     class="text-green-darker mr-2">
-                        {{ $article->author()->name() }}
+                    {{ $article->author()->name() }}
                 </a>
                 <span class="block text-sm">published {{ $article->createdAt()->format('j M, Y') }}</span>
             </div>

--- a/tests/Feature/ArticleTest.php
+++ b/tests/Feature/ArticleTest.php
@@ -326,7 +326,7 @@ class ArticleTest extends BrowserKitTestCase
         factory(Article::class)->create([
             'slug' => 'my-first-article',
             'original_url' => 'https://joedixon.co.uk/my-first-article',
-            'published_at' => now()
+            'published_at' => now(),
         ]);
 
         $this->get('/articles/my-first-article')

--- a/tests/Feature/ArticleTest.php
+++ b/tests/Feature/ArticleTest.php
@@ -49,7 +49,7 @@ class ArticleTest extends BrowserKitTestCase
             'body' => 'This article will go into depth on working with database migrations.',
             'tags' => [$tag->id()],
             'series' => $series->id(),
-            'status' => 'draft',
+            'published' => '0',
         ])
             ->assertRedirectedTo('/articles/using-database-migrations')
             ->assertSessionHas('success', 'Article successfully created!');
@@ -63,7 +63,7 @@ class ArticleTest extends BrowserKitTestCase
         $this->post('/articles', [
             'title' => 'Using database migrations',
             'body' => 'This article will go into depth on working with database migrations.',
-            'status' => 'publish',
+            'published' => '1',
         ])
             ->assertRedirectedTo('/articles/using-database-migrations')
             ->followRedirects()
@@ -78,7 +78,7 @@ class ArticleTest extends BrowserKitTestCase
         $this->post('/articles', [
             'title' => 'Using database migrations',
             'body' => 'This article will go into depth on working with database migrations.',
-            'status' => 'draft',
+            'published' => '0',
         ])
             ->assertRedirectedTo('/articles/using-database-migrations')
             ->followRedirects()
@@ -168,7 +168,7 @@ class ArticleTest extends BrowserKitTestCase
             'body' => 'This article will go into depth on working with database migrations.',
             'tags' => [$tag->id()],
             'series' => $series->id(),
-            'status' => 'publish',
+            'published' => '1',
         ])
             ->assertRedirectedTo('/articles/using-database-migrations')
             ->assertSessionHas('success', 'Article successfully updated!');
@@ -190,7 +190,7 @@ class ArticleTest extends BrowserKitTestCase
         $this->put('/articles/my-first-article', [
             'title' => 'Using database migrations',
             'body' => 'This article will go into depth on working with database migrations.',
-            'status' => 'publish',
+            'published' => '1',
         ])
             ->assertRedirectedTo('/articles/using-database-migrations')
             ->followRedirects()
@@ -213,7 +213,7 @@ class ArticleTest extends BrowserKitTestCase
         $this->put('/articles/my-first-article', [
             'title' => 'Using database migrations',
             'body' => 'This article will go into depth on working with database migrations.',
-            'status' => 'draft',
+            'published' => '0',
         ])
             ->assertRedirectedTo('/articles/using-database-migrations')
             ->followRedirects()
@@ -323,7 +323,11 @@ class ArticleTest extends BrowserKitTestCase
     /** @test */
     public function custom_canonical_urls_are_rendered()
     {
-        factory(Article::class)->create(['slug' => 'my-first-article', 'original_url' => 'https://joedixon.co.uk/my-first-article', 'published_at' => now()]);
+        factory(Article::class)->create([
+            'slug' => 'my-first-article',
+            'original_url' => 'https://joedixon.co.uk/my-first-article',
+            'published_at' => now()
+        ]);
 
         $this->get('/articles/my-first-article')
             ->see('<link rel="canonical" href="https://joedixon.co.uk/my-first-article" />');

--- a/tests/Integration/Jobs/CreateArticleTest.php
+++ b/tests/Integration/Jobs/CreateArticleTest.php
@@ -16,11 +16,33 @@ class CreateArticleTest extends TestCase
     {
         $user = $this->createUser();
 
-        $article = $this->dispatch(new CreateArticle('Title', 'Body', $user, ['original_url' => 'https://laravel.io']));
+        $article = $this->dispatch(new CreateArticle('Title', 'Body', $user, false, ['original_url' => 'https://laravel.io']));
 
         $this->assertEquals('Title', $article->title());
         $this->assertEquals('Body', $article->body());
         $this->assertEquals('https://laravel.io', $article->canonicalUrl());
+    }
+
+    /** @test */
+    public function we_can_create_an_article_and_publish_it()
+    {
+        $user = $this->createUser();
+
+        $article = $this->dispatch(new CreateArticle('Title', 'Body', $user, true, ['original_url' => 'https://laravel.io']));
+
+        $this->assertNotNull($article->publishedAt());
+        $this->assertTrue($article->isPublished());
+    }
+
+    /** @test */
+    public function we_can_create_a_draft_article()
+    {
+        $user = $this->createUser();
+
+        $article = $this->dispatch(new CreateArticle('Title', 'Body', $user, false, ['original_url' => 'https://laravel.io']));
+
+        $this->assertNull($article->publishedAt());
+        $this->assertTrue($article->isNotPublished());
     }
 
     /** @test */
@@ -29,7 +51,7 @@ class CreateArticleTest extends TestCase
         $user = $this->createUser();
         $series = factory(Series::class)->create(['author_id' => $user->id()]);
 
-        $article = $this->dispatch(new CreateArticle('Title', 'Body', $user, [
+        $article = $this->dispatch(new CreateArticle('Title', 'Body', $user, false, [
             'original_url' => 'https://laravel.io',
             'series_id' => $series->id,
         ]));

--- a/tests/Integration/Jobs/UpdateArticleTest.php
+++ b/tests/Integration/Jobs/UpdateArticleTest.php
@@ -18,10 +18,34 @@ class UpdateArticleTest extends TestCase
         $user = $this->createUser();
         $article = factory(Article::class)->create(['author_id' => $user->id()]);
 
-        $article = $this->dispatch(new UpdateArticle($article, 'Title', 'Body'));
+        $article = $this->dispatch(new UpdateArticle($article, 'Title', 'Body', false));
 
         $this->assertEquals('Title', $article->title());
         $this->assertEquals('Body', $article->body());
+    }
+
+    /** @test */
+    public function we_can_publish_an_existing_article()
+    {
+        $user = $this->createUser();
+        $article = factory(Article::class)->create(['author_id' => $user->id()]);
+
+        $article = $this->dispatch(new UpdateArticle($article, 'Title', 'Body', true));
+
+        $this->assertNotNull($article->publishedAt());
+        $this->assertTrue($article->isPublished());
+    }
+
+    /** @test */
+    public function we_can_unpublish_an_existing_article()
+    {
+        $user = $this->createUser();
+        $article = factory(Article::class)->create(['author_id' => $user->id(), 'published_at' => now()]);
+
+        $article = $this->dispatch(new UpdateArticle($article, 'Title', 'Body', false));
+
+        $this->assertNull($article->publishedAt());
+        $this->assertTrue($article->isNotPublished());
     }
 
     /** @test */
@@ -31,7 +55,7 @@ class UpdateArticleTest extends TestCase
         $article = factory(Article::class)->create(['author_id' => $user->id()]);
         $series = factory(Series::class)->create(['author_id' => $user->id()]);
 
-        $article = $this->dispatch(new UpdateArticle($article, 'Title', 'Body', [
+        $article = $this->dispatch(new UpdateArticle($article, 'Title', 'Body', true, [
             'original_url' => 'https://laravel.io',
             'series' => $series->id,
         ]));
@@ -49,7 +73,7 @@ class UpdateArticleTest extends TestCase
         $series = factory(Series::class)->create();
         $article = factory(Article::class)->create(['author_id' => $user->id(), 'series_id' => $series->id]);
 
-        $article = $this->dispatch(new UpdateArticle($article, 'Title', 'Body'));
+        $article = $this->dispatch(new UpdateArticle($article, 'Title', 'Body', true));
 
         $this->assertEquals('Title', $article->title());
         $this->assertEquals('Body', $article->body());


### PR DESCRIPTION
This PR adds support for setting the status of an article - draft or published.

I've added a `published_at` field to the `articles` table. If this date is populated, the article is live, if it's null, it's a draft.

There is a dropdown button on the article form which allows the user to choose the status when creating or editing an article.

<img width="1115" alt="Screenshot 2020-04-23 at 20 45 49" src="https://user-images.githubusercontent.com/3438564/80142838-bf11ce00-85a3-11ea-9e24-819b14d27cb1.png">
