### PR TITLE
Post-launch tidy of articles

### DIFF
--- a/app/Http/Livewire/ShowArticles.php
+++ b/app/Http/Livewire/ShowArticles.php
@@ -30,6 +30,9 @@ final class ShowArticles extends Component
     public function render(): View
     {
         $articles = Article::published();
+        $tags = Tag::whereHas('articles', function ($query) {
+            $query->published();
+        })->orderBy('name')->get();
 
         if ($this->tag) {
             $articles->forTag($this->tag);
@@ -39,6 +42,7 @@ final class ShowArticles extends Component
 
         return view('livewire.show-articles', [
             'articles' => $articles->paginate(10),
+            'tags' => $tags,
             'selectedTag' => $this->tag,
             'selectedSortBy' => $this->sortBy,
         ]);

--- a/resources/views/livewire/show-articles.blade.php
+++ b/resources/views/livewire/show-articles.blade.php
@@ -27,13 +27,13 @@
                 <div class="flex items-center justify-between mt-6">
                     <div class="flex items-center">
                         <div class="flex-shrink-0">
-                            <a href="#">
+                            <a href="{{ route('profile', $article->author()->username()) }}">
                                 <img class="h-10 w-10 rounded-full" src="{{ $article->author()->gravatarUrl($avatarSize ?? 250) }}" alt="{{ $article->author()->name }}" />
                             </a>
                         </div>
                         <div class="ml-3">
                             <p class="text-sm leading-5 font-medium text-gray-900">
-                                <a href="#">
+                                <a href="{{ route('profile', $article->author()->username()) }}">
                                     {{ $article->author()->name() }}
                                 </a>
                             </p>

--- a/resources/views/livewire/show-articles.blade.php
+++ b/resources/views/livewire/show-articles.blade.php
@@ -82,7 +82,7 @@
                 </button>
             </li>   
 
-            @foreach (App\Models\Tag::whereHas('articles')->orderBy('name')->get() as $tag)
+            @foreach ($tags as $tag)
                 <li class="{{ $selectedTag === $tag->slug() ? ' active' : '' }}">
                     <button wire:click="toggleTag('{{ $tag->slug() }}')">
                         {{ $tag->name() }}

--- a/resources/views/livewire/show-articles.blade.php
+++ b/resources/views/livewire/show-articles.blade.php
@@ -75,6 +75,13 @@
             </button>
         </span>
 
+        <a 
+            href="{{ route('articles.create') }}"
+            class="button button-primary button-full mb-4"
+        >
+            Create Article
+        </a>
+
         <ul class="tags">
             <li class="{{ ! $selectedTag ? ' active' : '' }}">
                 <button wire:click="toggleTag('')">

--- a/resources/views/users/articles.blade.php
+++ b/resources/views/users/articles.blade.php
@@ -23,7 +23,7 @@
 @section('content')
     <div class="container mx-auto px-4 py-8 flex flex-wrap flex-col-reverse lg:flex-row">
         <div class="w-full md:w-3/4 md:pr-3">
-            @foreach($articles as $article)
+            @forelse($articles as $article)
                 <div class="pb-8 mb-8 border-b-2">
                     <div>
                         @if ($article->isNotPublished())
@@ -102,7 +102,11 @@
                         </div>
                     </div>
                 </div>
-            @endforeach
+            @empty
+                <p class="text-gray-600 text-base">
+                    You haven't created any articles yet
+                </p>
+            @endforelse
 
             {{ $articles->links() }}
         </div>

--- a/tests/Feature/ArticleTest.php
+++ b/tests/Feature/ArticleTest.php
@@ -618,4 +618,18 @@ class ArticleTest extends BrowserKitTestCase
 
         Notification::assertSentTo($user, ArticleApprovedNotification::class);
     }
+
+    /** @test */
+    public function tags_are_not_rendered_for_unpublished_articles()
+    {
+        $tag = factory(Tag::class)->create(['name' => 'Test Tag']);
+        $article = factory(Article::class)->create([
+            'slug' => 'my-first-article',
+            'submitted_at' => now()
+        ]);
+        $article->syncTags([$tag->id]);
+
+        $this->get('/articles')
+            ->dontSee('Test Tag');
+    }
 }


### PR DESCRIPTION
- Resolves #543 
- Resolves #538
- Adds CTA to create articles on the overview page
- Add message when no articles created

<img width="1315" alt="Screenshot 2020-06-29 at 21 01 52" src="https://user-images.githubusercontent.com/3438564/86050797-45d3a300-ba4c-11ea-8397-e264a529dc94.png">

<img width="819" alt="Screenshot 2020-06-29 at 21 12 16" src="https://user-images.githubusercontent.com/3438564/86051389-3bfe6f80-ba4d-11ea-9c6d-acf4edfcbe71.png">
