### PR TITLE
Move Enlightn to own workflow

### DIFF
--- a/.github/workflows/enlightn.yml
+++ b/.github/workflows/enlightn.yml
@@ -1,4 +1,4 @@
-name: Enlightn Checks
+name: Enlightn
 
 on: [push, pull_request]
 

--- a/.github/workflows/enlightn.yml
+++ b/.github/workflows/enlightn.yml
@@ -1,0 +1,46 @@
+name: Enlightn Checks
+
+on: [push, pull_request]
+
+jobs:
+  enlightn:
+    env:
+      ENLIGHTN_USERNAME: ${{ secrets.ENLIGHTN_USERNAME }}
+      ENLIGHTN_API_TOKEN: ${{ secrets.ENLIGHTN_API_TOKEN }}
+      ENLIGHTN_GITHUB_REPO: ${{ github.repository }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, json
+          coverage: none
+
+      - name: Install Composer dependencies with Enlightn Pro
+        if: env.ENLIGHTN_API_TOKEN
+        run: |
+          composer config http-basic.satis.laravel-enlightn.com "$ENLIGHTN_USERNAME" "$ENLIGHTN_API_TOKEN"
+          composer config repositories.enlightn composer https://satis.laravel-enlightn.com
+          composer require --prefer-dist --no-interaction enlightn/enlightnpro
+
+      - name: Install Composer dependencies
+        if: ${{ !env.ENLIGHTN_API_TOKEN }}
+        run: composer install --prefer-dist --no-interaction
+
+      - name: Run Enlightn Checks and Trigger the Enlightn Bot
+        if: github.event_name == 'pull_request' && env.ENLIGHTN_API_TOKEN
+        run: |
+          cp .env.example .env
+          php artisan enlightn --ci --report --review --issue=${{ github.event.number }}
+
+      - name: Run Enlightn Checks
+        if: ${{ github.event_name != 'pull_request' || !env.ENLIGHTN_API_TOKEN }}
+        run: |
+          cp .env.example .env
+          php artisan enlightn --ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,17 +14,11 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.0
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, json
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
           coverage: none
 
       - name: Install Composer dependencies
-        env:
-          ENLIGHTN_USERNAME: ${{ secrets.ENLIGHTN_USERNAME }}
-          ENLIGHTN_API_TOKEN: ${{ secrets.ENLIGHTN_API_TOKEN }}
-        run: |
-          composer config http-basic.satis.laravel-enlightn.com "$ENLIGHTN_USERNAME" "$ENLIGHTN_API_TOKEN"
-          composer config repositories.enlightn composer https://satis.laravel-enlightn.com
-          composer require --prefer-dist --no-interaction enlightn/enlightnpro
+        run: composer install --prefer-dist --no-interaction
 
       - name: Install NPM dependencies
         run: npm ci
@@ -34,16 +28,6 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
-
-      - name: Run Enlightn Checks and Trigger the Enlightn Bot
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          ENLIGHTN_USERNAME: ${{ secrets.ENLIGHTN_USERNAME }}
-          ENLIGHTN_API_TOKEN: ${{ secrets.ENLIGHTN_API_TOKEN }}
-          ENLIGHTN_GITHUB_REPO: ${{ github.repository }}
-        run: |
-          cp .env.example .env
-          php artisan enlightn --ci --report --review --issue=${{ github.event.number }}
 
       - name: Deploy
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
After some more digging, I found that secrets aren't available to forks even though there is a [proposal under consideration](https://github.community/t/make-secrets-available-to-builds-of-forks/16166).

@driesvints, I'm moving Enlightn to its own workflow. This workflow should run in all scenarios (whether or not secrets are accessible). If secrets are available the Pro package will be pulled in and the bot will be triggered. If not available, the Enlightn CI will be triggered without Pro.

It would be interesting to see that if an owner/maintainer triggers a workflow on a fork, whether that makes secrets available.

Nevertheless, this should be a foolproof way for now. Sorry for all the troubles!