### PR TITLE
Use Unsplash images for articles

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -2,18 +2,18 @@
 
 namespace App\Models;
 
-use Carbon\Carbon;
+use App\Helpers\HasAuthor;
+use App\Helpers\HasLikes;
 use App\Helpers\HasSlug;
 use App\Helpers\HasTags;
-use App\Helpers\HasLikes;
-use App\Helpers\HasAuthor;
-use Illuminate\Support\Str;
-use Laravel\Scout\Searchable;
 use App\Helpers\HasTimestamps;
 use App\Helpers\PreparesSearch;
-use Illuminate\Database\Eloquent\Model;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Laravel\Scout\Searchable;
 
 final class Article extends Model
 {

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -2,18 +2,18 @@
 
 namespace App\Models;
 
-use App\Helpers\HasAuthor;
-use App\Helpers\HasLikes;
+use Carbon\Carbon;
 use App\Helpers\HasSlug;
 use App\Helpers\HasTags;
-use App\Helpers\HasTimestamps;
-use App\Helpers\PreparesSearch;
-use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
+use App\Helpers\HasLikes;
+use App\Helpers\HasAuthor;
 use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
+use App\Helpers\HasTimestamps;
+use App\Helpers\PreparesSearch;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 final class Article extends Model
 {
@@ -82,9 +82,13 @@ final class Article extends Model
         return Str::limit(strip_tags(md_to_html($this->body())), $limit);
     }
 
-    public function heroImage(): string
+    public function heroImage($width = 400, $height = 300): string
     {
-        return $this->hero_image ?: asset('images/default-background.svg');
+        if ($this->hero_image) {
+            return "https://source.unsplash.com/{$this->hero_image}/{$width}x{$height}";
+        }
+
+        return asset('images/default-background.svg');
     }
 
     public function originalUrl(): ?string

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -2,11 +2,11 @@
 
 namespace Database\Seeders;
 
-use App\Models\Article;
-use App\Models\Thread;
 use App\Models\User;
-use Illuminate\Database\Eloquent\Factories\Sequence;
+use App\Models\Thread;
+use App\Models\Article;
 use Illuminate\Database\Seeder;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 
 class UserSeeder extends Seeder
 {
@@ -32,7 +32,7 @@ class UserSeeder extends Seeder
                             [
                                 'submitted_at' => now(),
                                 'approved_at' => now(),
-                                'hero_image' => 'https://source.unsplash.com/800x450/?programming,laravel',
+                                'hero_image' => 'sxiSod0tyYQ',
                             ],
                             ['submitted_at' => now(), 'approved_at' => now()],
                             ['submitted_at' => now()],

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -2,11 +2,11 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-use App\Models\Thread;
 use App\Models\Article;
-use Illuminate\Database\Seeder;
+use App\Models\Thread;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Database\Seeder;
 
 class UserSeeder extends Seeder
 {

--- a/resources/views/components/articles/summary.blade.php
+++ b/resources/views/components/articles/summary.blade.php
@@ -1,14 +1,13 @@
 @props([
-    'image' => null,
     'article',
     'isFeatured' => false,
 ])
 
 <div class="h-full mb-8 md:mb-0 flex flex-col place-content-between">
     <div class="break-words">
-        @if ($image)
+        @if ($isFeatured)
             <a href="{{ route('articles.show', $article->slug()) }}">
-                <div class="w-full h-72 mb-6 rounded-lg bg-center bg-cover" style="background-image: url({{ $image }});"></div>
+                <div class="w-full h-72 mb-6 rounded-lg bg-center bg-cover bg-gray-900" style="background-image: url({{ $article->heroImage() }});"></div>
             </a>
         @endif
 


### PR DESCRIPTION
Uses [Unsplash Source](https://source.unsplash.com/) to pull in images for articles. Doing it this way means we only have to store an Unsplash image ID in the database. Unsplash source will get us the image in the required dimensions.

The Unsplash Source website states: 

> Source is built for use in small, low-traffic applications. For production uses, we recommend the official Unsplash API which has more robust features and supports high-traffic use cases.

It doesn't go into detail of what a low-traffic app is. I would prefer to use this over the Unsplash API as we don't need to worry about creating an app and we don't have to make an API call to get the desired image URL. I'm happy to swap this out if preferred.