### PR TITLE
fix: stat popout elements width

### DIFF
--- a/resources/views/components/stat-popout.blade.php
+++ b/resources/views/components/stat-popout.blade.php
@@ -5,7 +5,7 @@
 <div {{ $attributes->merge(['class' => 'member w-64 shadow-xl rounded']) }}>
     <div class="flex justify-between border-b p-3 bg-white rounded-t">
         <div class="flex flex-col items-center text-lio-500 text-center">
-            <span class="flex w-8 h-8 bg-lio-100 font-bold rounded items-center justify-center mb-1.5">
+            <span class="flex min-w-8 h-8 px-2 bg-lio-100 font-bold rounded items-center justify-center mb-1.5">
                 {{ $user->solutions_count }}
             </span>
 
@@ -13,7 +13,7 @@
         </div>
 
         <div class="flex flex-col items-center text-lio-500 text-center">
-            <span class="flex w-8 h-8 bg-lio-100 font-bold rounded items-center justify-center mb-1.5">
+            <span class="flex min-w-8 h-8 px-2 bg-lio-100 font-bold rounded items-center justify-center mb-1.5">
                 {{ $user->threads_count }}
             </span>
 
@@ -21,7 +21,7 @@
         </div>
 
         <div class="flex flex-col items-center text-lio-500 text-center">
-            <span class="flex w-8 h-8 bg-lio-100 font-bold rounded items-center justify-center mb-1.5">
+            <span class="flex min-w-8 h-8 px-2 bg-lio-100 font-bold rounded items-center justify-center mb-1.5">
                 {{ $user->replies_count }}
             </span>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,6 +47,9 @@ module.exports = {
             fontFamily: {
                 sans: ['Inter', ...defaultTheme.fontFamily.sans],
             },
+            minWidth: {
+                8: '2rem',
+            },
             maxWidth: {
                 14: '14rem',
             },


### PR DESCRIPTION
Hello 👋🏻 

I came across this issue of that box support only less than 2 digits numbers. So I came up with this solution.

# Before
![Screenshot from 2021-09-25 21-34-55](https://user-images.githubusercontent.com/60013703/134785470-8f0be451-0b46-4bb0-bded-3f1f6e91ead3.png)

 # After
![Screenshot from 2021-09-25 21-39-25](https://user-images.githubusercontent.com/60013703/134785475-6a9eecd0-2462-476c-a32a-0cc05989b7e5.png)

