### PR TITLE
Prevented current article showing in trending articles section

### DIFF
--- a/app/Http/Controllers/Articles/ArticlesController.php
+++ b/app/Http/Controllers/Articles/ArticlesController.php
@@ -50,7 +50,7 @@ class ArticlesController extends Controller
         $trendingArticles = Cache::remember('trendingArticles', now()->addHour(), function () use ($article) {
             return Article::published()
                 ->trending()
-                ->where('id', '!=', $article->id)
+                ->whereKeyNot($article->id)
                 ->limit(3)
                 ->get();
         });

--- a/app/Http/Controllers/Articles/ArticlesController.php
+++ b/app/Http/Controllers/Articles/ArticlesController.php
@@ -47,9 +47,10 @@ class ArticlesController extends Controller
             404,
         );
 
-        $trendingArticles = Cache::remember('trendingArticles', now()->addHour(), function () {
+        $trendingArticles = Cache::remember('trendingArticles', now()->addHour(), function () use ($article) {
             return Article::published()
                 ->trending()
+                ->where('id', '!=', $article->id)
                 ->limit(3)
                 ->get();
         });


### PR DESCRIPTION
Hey!

This PRs only a small one, but it updates something that I just noticed while on the site.

Say if you go to an article, such as https://laravel.io/articles/using-database-transactions-to-write-safer-laravel-code, when you scroll to the bottom to the "Other articles you might like" section, the current article is in the list (the screenshot shows this).

I know that this isn't really a big issue and is probably unlikely to happen often. But, I've made a small PR which _should_ prevent it in the future.

If this is something you might want to pull in, let me know if there are any changes I need to make :smile:

<img width="1428" alt="Screenshot 2021-09-27 at 15 24 43" src="https://user-images.githubusercontent.com/39652331/134929291-d4b13a4e-d564-40ee-b4df-ddc3aa187695.png">
