### PR TITLE
Fix #695 - Add word breaks to titles

### DIFF
--- a/resources/views/articles/create.blade.php
+++ b/resources/views/articles/create.blade.php
@@ -7,7 +7,7 @@
         <div class="container mx-auto flex justify-between items-center px-4">
             <h1 class="text-xl py-4 text-gray-900">
                 <a href="{{ route('user.articles') }}">Your Articles</a>
-                > {{ $title }}
+                > <span class="break-all">{{ $title }}</span>
             </h1>
         </div>
     </div>

--- a/resources/views/articles/edit.blade.php
+++ b/resources/views/articles/edit.blade.php
@@ -7,7 +7,7 @@
         <div class="container mx-auto flex justify-between items-center px-4">
             <h1 class="text-xl py-4 text-gray-900">
                 <a href="{{ route('user.articles') }}">Your Articles</a>
-                > {{ $title }}
+                > <span class="break-all">{{ $title }}</span>
             </h1>
         </div>
     </div>

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -38,7 +38,7 @@
                         </div>
                     @endif
 
-                    <h1 class="text-white text-5xl font-bold mb-4">
+                    <h1 class="text-white text-5xl font-bold mb-4 break-all">
                         {{ $article->title() }}
                     </h1>
 

--- a/resources/views/forum/threads/create.blade.php
+++ b/resources/views/forum/threads/create.blade.php
@@ -7,7 +7,7 @@
         <div class="container mx-auto flex justify-between items-center px-4">
             <h1 class="text-xl py-4 text-gray-900">
                 <a href="{{ route('forum') }}">Forum</a>
-                > {{ $title }}
+                > <span class="break-all">{{ $title }}</span>
             </h1>
         </div>
     </div>

--- a/resources/views/forum/threads/edit.blade.php
+++ b/resources/views/forum/threads/edit.blade.php
@@ -7,7 +7,7 @@
         <div class="container mx-auto flex justify-between items-center px-4">
             <h1 class="text-xl py-4 text-gray-900">
                 <a href="{{ route('forum') }}">Forum</a>
-                > {{ $title }}
+                > <span class="break-all">{{ $title }}</span>
             </h1>
         </div>
     </div>

--- a/resources/views/forum/threads/show.blade.php
+++ b/resources/views/forum/threads/show.blade.php
@@ -8,7 +8,7 @@
         <h1 class="flex items-center gap-x-3.5 text-xl font-semibold lg:text-3xl">
             <a href="{{ route('forum') }}" class="text-gray-400 hover:underline">Forum</a>
             <x-heroicon-o-chevron-right class="w-6 h-6" />
-            {{ $title }}
+            <span class="break-all">{{ $title }}</span>
         </h1>
     </section>
 @endsection

--- a/resources/views/layouts/small.blade.php
+++ b/resources/views/layouts/small.blade.php
@@ -3,7 +3,7 @@
 @section('body')
     <div class="flex items-center justify-center py-8 md:py-20 bg-gray-50">
         <div class="w-full md:w-1/2 lg:w-1/3 xl:w-1/4">
-            <h1 class="text-4xl text-gray-700 text-center mb-2 font-bold">{{ $title }}</h1>
+            <h1 class="text-4xl text-gray-700 text-center mb-2 font-bold break-all">{{ $title }}</h1>
             <div class="p-8 md:border-2 md:rounded md:bg-gray-100">
                 @include('layouts._alerts')
 

--- a/resources/views/replies/edit.blade.php
+++ b/resources/views/replies/edit.blade.php
@@ -5,7 +5,7 @@
 @section('subnav')
     <div class="bg-white border-b">
         <div class="container mx-auto flex justify-between items-center px-4">
-            <h1 class="text-xl py-4 text-gray-900">{{ $title }}</h1>
+            <h1 class="text-xl py-4 text-gray-900 break-all">{{ $title }}</h1>
         </div>
     </div>
 @endsection

--- a/resources/views/users/articles.blade.php
+++ b/resources/views/users/articles.blade.php
@@ -5,7 +5,7 @@
 @section('subnav')
     <div class="bg-white border-b">
         <div class="container mx-auto flex justify-between items-center px-4">
-            <h1 class="text-xl py-4 text-gray-900">
+            <h1 class="text-xl py-4 text-gray-900 break-all">
                 {{ $title }}
             </h1>
 


### PR DESCRIPTION
Hey!

This fixes #695 . I've added `break-all` because `break-words` did not always break long strings.

Have a great day 😃 