### PR TITLE
fix: top authors widget ranking

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -253,7 +253,7 @@ final class User extends Authenticatable implements MustVerifyEmail
     {
         return $query->withCount(['articles as articles_count' => function ($query) use ($inLastDays) {
             if ($inLastDays) {
-                $query->where('articles.submitted_at', '>', now()->subDays($inLastDays));
+                $query->where('articles.approved_at', '>', now()->subDays($inLastDays));
             }
 
             return $query;


### PR DESCRIPTION
@joedixon

Following #714. I found that we have to rank authors by approved articles.