### PR TITLE
Remember me for GitHub authentication

### DIFF
--- a/app/Http/Controllers/Auth/GithubController.php
+++ b/app/Http/Controllers/Auth/GithubController.php
@@ -54,7 +54,7 @@ class GithubController extends Controller
     {
         $this->dispatchNow(new UpdateProfile($user, ['github_username' => $socialiteUser->getNickname()]));
 
-        Auth::login($user);
+        Auth::login($user, true);
 
         return redirect()->route('profile');
     }


### PR DESCRIPTION
This fixes #689 by passing `true` as second parameter to Auth::login() when logging in using github.