### PR TITLE
Add missing group by in the feedQuery on the Thread model (result in an error on MariaDB)

### DIFF
--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -224,7 +224,18 @@ final class Thread extends Model implements ReplyAble, SubscriptionAble, Feedabl
                     ->where('replies.replyable_type', static::TABLE);
             })
             ->orderBy('latest_creation', 'DESC')
-            ->groupBy('threads.id')
+            ->groupBy(
+                'threads.id',
+                'threads.author_id',
+                'threads.subject',
+                'threads.body',
+                'threads.slug',
+                'threads.created_at',
+                'threads.updated_at',
+                'threads.solution_reply_id',
+                'threads.resolved_by',
+
+            )
             ->select('threads.*', DB::raw('
                 CASE WHEN COALESCE(MAX(replies.created_at), 0) > threads.created_at
                 THEN COALESCE(MAX(replies.created_at), 0)


### PR DESCRIPTION
After running the project I got the error:

![image](https://user-images.githubusercontent.com/2026498/142052523-25d6d8e8-801f-4d21-b63c-81e99e4cbe52.png)

```
SQLSTATE[42000]: Syntax error or access violation: 1055 'laravelio.threads.author_id' isn't in GROUP BY (SQL: select count(*) as aggregate from (select `threads`.*, CASE WHEN COALESCE(MAX(replies.created_at), 0) > threads.created_at THEN COALESCE(MAX(replies.created_at), 0) ELSE threads.created_at END AS latest_creation from `threads` left join `replies` on `threads`.`id` = `replies`.`replyable_id` and `replies`.`replyable_type` = threads group by `threads`.`id`) as `aggregate_table`) 
```

This PR adds the missing group by columns.