### PR TITLE
Performance improvements for seeders

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -20,7 +20,7 @@ class UserFactory extends Factory
             'username' => $this->faker->unique()->userName,
             'password' => $password ?: $password = bcrypt('secret'),
             'remember_token' => Str::random(10),
-            'github_id' => $this->faker->numberBetween(10000, 99999),
+            'github_id' => $this->faker->unique()->numberBetween(10000, 99999),
             'github_username' => $this->faker->unique()->userName,
             'twitter' => $this->faker->unique()->userName,
             'banned_at' => null,

--- a/database/seeders/LikeSeeder.php
+++ b/database/seeders/LikeSeeder.php
@@ -8,6 +8,7 @@ use App\Models\Thread;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\DB;
 
 class LikeSeeder extends Seeder
 {
@@ -16,26 +17,32 @@ class LikeSeeder extends Seeder
     public function run()
     {
         $users = User::all();
-        $articles = Article::all();
-        $replies = Reply::all();
-        $threads = Thread::all();
+        $articles = Article::all()->random(50);
+        $replies = Reply::all()->random(50);
+        $threads = Thread::all()->random(50);
 
-        $articles->random(100)->each(function ($article) use ($users) {
+        DB::beginTransaction();
+        foreach ($articles as $article) {
             foreach ($users->random(rand(1, 10)) as $user) {
                 $article->likedBy($user);
             }
-        });
+        }
+        DB::commit();
 
-        $replies->random(50)->each(function ($reply) use ($users) {
+        DB::beginTransaction();
+        foreach ($replies as $reply) {
             foreach ($users->random(rand(1, 10)) as $user) {
                 $reply->likedBy($user);
             }
-        });
+        }
+        DB::commit();
 
-        $threads->random(50)->each(function ($thread) use ($users) {
+        DB::beginTransaction();
+        foreach ($threads as $thread) {
             foreach ($users->random(rand(1, 10)) as $user) {
                 $thread->likedBy($user);
             }
-        });
+        }
+        DB::commit();
     }
 }

--- a/database/seeders/NotificationSeeder.php
+++ b/database/seeders/NotificationSeeder.php
@@ -6,6 +6,7 @@ use App\Models\Reply;
 use App\Notifications\NewReplyNotification;
 use Illuminate\Database\Seeder;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\DB;
 use Ramsey\Uuid\Uuid;
 
 class NotificationSeeder extends Seeder
@@ -14,7 +15,10 @@ class NotificationSeeder extends Seeder
 
     public function run()
     {
-        Reply::all()->each(function (Reply $reply) {
+        $replies = Reply::with(['authorRelation.notifications', 'replyAbleRelation'])->get();
+
+        DB::beginTransaction();
+        foreach ($replies as $reply) {
             $reply->author()->notifications()->create([
                 'id' => Uuid::uuid4()->toString(),
                 'type' => NewReplyNotification::class,
@@ -28,6 +32,7 @@ class NotificationSeeder extends Seeder
                 'created_at' => $reply->createdAt(),
                 'updated_at' => $reply->createdAt(),
             ]);
-        });
+        }
+        DB::commit();
     }
 }

--- a/database/seeders/ReplySeeder.php
+++ b/database/seeders/ReplySeeder.php
@@ -4,33 +4,37 @@ namespace Database\Seeders;
 
 use App\Models\Reply;
 use App\Models\Thread;
-use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class ReplySeeder extends Seeder
 {
     public function run()
     {
-        $users = User::all();
+        $userIds = array_flip(DB::table('users')->pluck('id')->toArray());
         $threads = Thread::all();
 
+        DB::beginTransaction();
         // Create 5 replies for each thread from random users.
-        $threads->each(function ($thread) use ($users) {
+        foreach ($threads as $thread) {
             Reply::factory()
                 ->count(5)
                 ->state(new Sequence(
                     fn () => [
-                        'author_id' => $users->random()->id,
+                        'author_id' => array_rand($userIds),
                         'replyable_id' => $thread->id,
                     ],
                 ))
                 ->createQuietly();
-        });
+        }
+        DB::commit();
 
+        DB::beginTransaction();
         // Give 10 random threads a solution.
-        $threads->random(20)->each(function (Thread $thread) {
-            $thread->markSolution($thread->repliesRelation()->get()->random(), $thread->author());
-        });
+        foreach ($threads->random(20) as $thread) {
+            $thread->markSolution($thread->repliesRelation()->get()->load('replyAbleRelation')->random(), $thread->author());
+        }
+        DB::commit();
     }
 }

--- a/database/seeders/TagSeeder.php
+++ b/database/seeders/TagSeeder.php
@@ -6,6 +6,7 @@ use App\Models\Article;
 use App\Models\Tag;
 use App\Models\Thread;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class TagSeeder extends Seeder
 {
@@ -74,22 +75,20 @@ class TagSeeder extends Seeder
             ['name' => 'Octane', 'slug' => 'octane'],
         ]));
 
-        Article::all()->each(function ($article) use ($tags) {
-            $article->syncTags(
-                $tags->random(rand(0, $tags->count()))
-                    ->take(3)
-                    ->pluck('id')
-                    ->toArray(),
-            );
-        });
+        $tagIds = array_flip($tags->pluck('id')->toArray());
+        $articles = Article::all();
+        $threads = Thread::all();
 
-        Thread::all()->each(function ($article) use ($tags) {
-            $article->syncTags(
-                $tags->random(rand(0, $tags->count()))
-                    ->take(3)
-                    ->pluck('id')
-                    ->toArray(),
-            );
-        });
+        DB::beginTransaction();
+        foreach ($articles as $article) {
+            $article->syncTags(array_rand($tagIds, 3));
+        }
+        DB::commit();
+
+        DB::beginTransaction();
+        foreach ($threads as $thread) {
+            $thread->syncTags(array_rand($tagIds, 3));
+        }
+        DB::commit();
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -7,6 +7,7 @@ use App\Models\Thread;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class UserSeeder extends Seeder
 {
@@ -21,6 +22,7 @@ class UserSeeder extends Seeder
             'type' => User::ADMIN,
         ]);
 
+        DB::beginTransaction();
         User::factory()
             ->count(100)
             ->has(Thread::factory()->count(2), 'threadsRelation')
@@ -40,6 +42,7 @@ class UserSeeder extends Seeder
                     ),
             )
             ->createQuietly();
+        DB::commit();
 
         Article::published()
             ->inRandomOrder()


### PR DESCRIPTION
Hi, I made some improvements for issue #677. I managed to get all seeders below 1 second by grouping queries and fixing some n+1 queries.

<img width="790" alt="image" src="https://user-images.githubusercontent.com/75377381/142681005-179577e9-45e6-441a-9eac-00eedefdb206.png">
