### PR TITLE
Handle duplicate GitHub ID upon registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -9,9 +9,9 @@ use App\Jobs\RegisterUser;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class RegisterController extends Controller
 {
@@ -57,15 +57,19 @@ class RegisterController extends Controller
      * Create a new user instance after a valid registration.
      */
     protected function create(array $data): User
+
     {  
         try {
             $user = User::findByGithubId($data['github_id']);
             if ($user instanceof User) {
+
                 $this->error('errors.github_account_exists'); 
+
                 return redirect()->route('login');
             } 
         } catch (ModelNotFoundException $exception) {
             return $this->dispatchNow(RegisterUser::fromRequest(app(RegisterRequest::class)));
         }
+        
     } 
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -61,13 +61,12 @@ class RegisterController extends Controller
         try {
             $user = User::findByGithubId($data['github_id']);
             if ($user instanceof User) {
-
                 $this->error('errors.github_account_exists');
 
                 return redirect()->route('login');
             }
         } catch (ModelNotFoundException $exception) {
             return $this->dispatchNow(RegisterUser::fromRequest(app(RegisterRequest::class)));
-        } 
+        }
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -57,19 +57,17 @@ class RegisterController extends Controller
      * Create a new user instance after a valid registration.
      */
     protected function create(array $data): User
-
-    {  
+    {
         try {
             $user = User::findByGithubId($data['github_id']);
             if ($user instanceof User) {
 
-                $this->error('errors.github_account_exists'); 
+                $this->error('errors.github_account_exists');
 
                 return redirect()->route('login');
-            } 
+            }
         } catch (ModelNotFoundException $exception) {
             return $this->dispatchNow(RegisterUser::fromRequest(app(RegisterRequest::class)));
-        }
-        
-    } 
+        } 
+    }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -9,7 +9,6 @@ use App\Jobs\RegisterUser;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Validator;
 
@@ -58,15 +57,6 @@ class RegisterController extends Controller
      */
     protected function create(array $data): User
     {
-        try {
-            $user = User::findByGithubId($data['github_id']);
-            if ($user instanceof User) {
-                $this->error('errors.github_account_exists');
-
-                return redirect()->route('login');
-            }
-        } catch (ModelNotFoundException $exception) {
-            return $this->dispatchNow(RegisterUser::fromRequest(app(RegisterRequest::class)));
-        }
+        return $this->dispatchNow(RegisterUser::fromRequest(app(RegisterRequest::class)));
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -11,6 +11,7 @@ use App\Providers\RouteServiceProvider;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class RegisterController extends Controller
 {
@@ -56,7 +57,15 @@ class RegisterController extends Controller
      * Create a new user instance after a valid registration.
      */
     protected function create(array $data): User
-    {
-        return $this->dispatchNow(RegisterUser::fromRequest(app(RegisterRequest::class)));
-    }
+    {  
+        try {
+            $user = User::findByGithubId($data['github_id']);
+            if ($user instanceof User) {
+                $this->error('errors.github_account_exists'); 
+                return redirect()->route('login');
+            } 
+        } catch (ModelNotFoundException $exception) {
+            return $this->dispatchNow(RegisterUser::fromRequest(app(RegisterRequest::class)));
+        }
+    } 
 }

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Rules\UniqueGitHubUser;
 use Illuminate\Foundation\Http\FormRequest;
 
 class RegisterRequest extends FormRequest
@@ -19,7 +20,7 @@ class RegisterRequest extends FormRequest
             'username' => 'required|alpha_dash|max:40|unique:users',
             'rules' => 'accepted',
             'terms' => 'accepted',
-            'github_id' => 'required',
+            'github_id' => ['required', new UniqueGitHubUser],
         ];
     }
 

--- a/app/Rules/UniqueGitHubUser.php
+++ b/app/Rules/UniqueGitHubUser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Rules;
+
+use App\Concerns\SendsAlerts;
+use App\Models\User;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+final class UniqueGitHubUser implements Rule
+{
+    use SendsAlerts;
+
+    private User $user;
+
+    public function passes($attribute, $value): bool
+    {
+        try {
+            $this->user = User::findByGithubId($value);
+        } catch (ModelNotFoundException) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function message()
+    {
+        $this->error('errors.github_account_exists', [
+            'username' => '@'.$this->user->githubUsername(),
+            'login' => route('login'),
+        ]);
+    }
+}

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -1,4 +1,5 @@
 <?php 
+
 $githubUsername = is_array(session('githubData')) ? session('githubData')['username'] : '';
 
 return [
@@ -7,4 +8,5 @@ return [
     'github_invalid_state' => 'The request timed out. Please try again.',
     'github_account_too_young' => 'Your Github account needs to be older than 2 weeks in order to register.',
     'github_account_exists' => 'We already found a user with the given GitHub account (https://github/'.$githubUsername ?? ''.'). Would you like to login instead?'
+    
 ];

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -1,9 +1,10 @@
-<?php
+<?php 
+$githubUsername = is_array(session('githubData')) ? session('githubData')['username'] : '';
 
 return [
     'banned' => 'This account is banned.',
     'fields' => 'Something went wrong. Please review the fields below.',
     'github_invalid_state' => 'The request timed out. Please try again.',
     'github_account_too_young' => 'Your Github account needs to be older than 2 weeks in order to register.',
-    'github_account_exists' => 'We already found a user with the given GitHub account (https://github/'.session('githubData')['username'].'). Would you like to login instead?'
+    'github_account_exists' => 'We already found a user with the given GitHub account (https://github/'.$githubUsername ?? ''.'). Would you like to login instead?'
 ];

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -5,4 +5,5 @@ return [
     'fields' => 'Something went wrong. Please review the fields below.',
     'github_invalid_state' => 'The request timed out. Please try again.',
     'github_account_too_young' => 'Your Github account needs to be older than 2 weeks in order to register.',
+    'github_account_exists' => 'We already found a user with the given GitHub account (https://github/'.session('githubData')['username'].'). Would you like to login instead?'
 ];

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -7,6 +7,6 @@ return [
     'fields' => 'Something went wrong. Please review the fields below.',
     'github_invalid_state' => 'The request timed out. Please try again.',
     'github_account_too_young' => 'Your Github account needs to be older than 2 weeks in order to register.',
-    'github_account_exists' => 'We already found a user with the given GitHub account (https://github/'.$githubUsername ?? ''.'). Would you like to login instead?'
-    
+    'github_account_exists' => 'We already found a user with the given GitHub account (https://github/'.$githubUsername ?? ''.'). Would you like to login instead?',
+
 ];

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 $githubUsername = is_array(session('githubData')) ? session('githubData')['username'] : '';
 

--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -1,12 +1,9 @@
 <?php
 
-$githubUsername = is_array(session('githubData')) ? session('githubData')['username'] : '';
-
 return [
     'banned' => 'This account is banned.',
     'fields' => 'Something went wrong. Please review the fields below.',
     'github_invalid_state' => 'The request timed out. Please try again.',
     'github_account_too_young' => 'Your Github account needs to be older than 2 weeks in order to register.',
-    'github_account_exists' => 'We already found a user with the given GitHub account (https://github/'.$githubUsername ?? ''.'). Would you like to login instead?',
-
+    'github_account_exists' => 'We already found a user with the given GitHub account (:username). Would you like to <a href=":login">login</a> instead?',
 ];

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Contracts\Auth\PasswordBroker;
@@ -59,6 +60,24 @@ test('registration fails with non alpha dash username', function () {
         ->press('Register')
         ->seePageIs('/register')
         ->see('The username must only contain letters, numbers, dashes and underscores.');
+});
+
+test('registration fails with a duplicate github id', function () {
+    User::factory()->create(['github_id' => 123, 'github_username' => 'johndoe']);
+
+    session(['githubData' => ['id' => 123, 'username' => 'johndoe']]);
+
+    $this->visit('/register')
+        ->type('John Doe', 'name')
+        ->type('john.doe@example.com', 'email')
+        ->type('johndoe', 'username')
+        ->type('123', 'github_id')
+        ->type('johndoe', 'github_username')
+        ->check('rules')
+        ->check('terms')
+        ->press('Register')
+        ->seePageIs('/register')
+        ->see('We already found a user with the given GitHub account (@johndoe). Would you like to <a href="http://localhost/login">login</a> instead?');
 });
 
 test('users can resend the email verification', function () {


### PR DESCRIPTION
# What's inside
- This PR attempts to check the create method of the RegisterController to see if the user already exists. If positive, we present them with a view that says: We already found a user with the given GitHub account (link to it). Would you like to login instead? and then we sent them to the login page.

Resolves #775 

