### PR TITLE
Fix Help Others section scroll

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -119,7 +119,7 @@
                 </p>
             </div>
 
-            <div class="flex gap-4 mb-4 -mx-4 p-4 overflow-x-scroll lg:mb-10 lg:gap-8">
+            <div class="flex gap-4 mb-4 -mx-4 p-4 overflow-x-auto lg:mb-10 lg:gap-8">
                 @foreach ($latestThreads as $thread)
                     <div class="flex-shrink-0 w-11/12 lg:w-1/3 lg:flex-shrink">
                         <x-threads.summary :thread="$thread" />


### PR DESCRIPTION
Hello 👋🏻

Here I found an unnecessary scroll in large screen so I switch it to `auto` so the scroll appear only when can be used.

# Before
![Screenshot 2021-12-21 at 13-39-32 Laravel io](https://user-images.githubusercontent.com/60013703/146932182-f7f8ab69-c0a9-4b7e-94bb-bf33b7353d13.png)

# After
![Screenshot 2021-12-21 at 13-40-12 Laravel io](https://user-images.githubusercontent.com/60013703/146932217-03c7591c-c7a7-489f-a55a-87a263afed14.png)

