### PR TITLE
Add padding for suggested articles in large breakpoint

### DIFF
--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -142,7 +142,7 @@
     </article>
 
     <section>
-        <div class="container mx-auto py-6 px-4 lg:py-24 lg:px-0">
+        <div class="container mx-auto py-6 px-4 lg:py-24">
             <h2 class="text-4xl text-gray-900 font-bold">
                 Other articles you might like
             </h2>


### PR DESCRIPTION
Currently, when the browser window is exactly the same width as a responsive breakpoint, the suggested articles list has no padding:
<img width="1392" alt="Screen Shot 2021-12-21 at 11 51 38 AM" src="https://user-images.githubusercontent.com/24496030/146968426-0025fbcc-f09f-4fa2-8c2b-2bcac1818b5a.png">
This PR adds padding in the large breakpoint:
<img width="1392" alt="Screen Shot 2021-12-21 at 11 54 35 AM" src="https://user-images.githubusercontent.com/24496030/146968678-e5d664fd-7ec8-47e2-8d3b-e3c09b62a5a3.png">
