### PR TITLE
Remove border from code blocks

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -34,7 +34,7 @@ a > span > em {
 }
 
 pre .hljs {
-    @apply text-sm rounded p-4 border-2;
+    @apply p-4;
 }
 
 .forum-content code {


### PR DESCRIPTION
This PR removes the border from code blocks which appeared after the upgrade to Tailwind 3.0

**Before**
<img width="875" alt="Screenshot 2022-01-05 at 09 08 14" src="https://user-images.githubusercontent.com/3438564/148191062-dc4c2ad9-995a-410c-bc00-8ecc79f9b480.png">

**After**
<img width="869" alt="Screenshot 2022-01-05 at 09 09 26" src="https://user-images.githubusercontent.com/3438564/148191275-bf18de44-7bb7-4ced-8d66-8409b8d9ba87.png">

