### PR TITLE
Updates API token settings to show token when first generated

### DIFF
--- a/app/Http/Controllers/Settings/ApiTokenController.php
+++ b/app/Http/Controllers/Settings/ApiTokenController.php
@@ -19,7 +19,9 @@ class ApiTokenController extends Controller
 
     public function store(CreateApiTokenRequest $request)
     {
-        $this->dispatchSync(new CreateApiToken(Auth::user(), $request->name()));
+        $token = $this->dispatchSync(new CreateApiToken(Auth::user(), $request->name()));
+
+        $this->success('settings.api_token.created', ['token' => $token->plainTextToken]);
 
         return redirect()->route('settings.profile');
     }
@@ -27,6 +29,8 @@ class ApiTokenController extends Controller
     public function destroy(DeleteApiTokenRequest $request)
     {
         $this->dispatchSync(new DeleteApiToken(Auth::user(), $request->id()));
+
+        $this->success('settings.api_token.deleted');
 
         return redirect()->route('settings.profile');
     }

--- a/app/Jobs/CreateApiToken.php
+++ b/app/Jobs/CreateApiToken.php
@@ -3,22 +3,16 @@
 namespace App\Jobs;
 
 use App\Models\User;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
+use Laravel\Sanctum\NewAccessToken;
 
-class CreateApiToken implements ShouldQueue
+final class CreateApiToken
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     public function __construct(private User $user, private string $name)
     {
     }
 
-    public function handle(): void
+    public function handle(): NewAccessToken
     {
-        $this->user->createToken($this->name);
+        return $this->user->createToken($this->name);
     }
 }

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -6,7 +6,7 @@ return [
     'deleted' => 'Account was successfully removed.',
     'password.updated' => 'Password successfully changed!',
     'api_token' => [
-        'created' => 'API token created! Please copy the following token as it will not be shown again: :token',
+        'created' => 'API token created! Please copy the following token as it will not be shown again: <span class="bg-white text-gray-800 px-1">:token</span>',
         'deleted' => 'API token successfully removed.',
     ],
 ];

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -5,5 +5,8 @@ return [
     'updated' => 'Settings successfully saved! If you changed your email address you\'ll receive an email address to re-confirm it.',
     'deleted' => 'Account was successfully removed.',
     'password.updated' => 'Password successfully changed!',
-
+    'api_token' => [
+        'created' => 'API token created! Please copy the following token as it will not be shown again: :token',
+        'deleted' => 'API token successfully removed.',
+    ],
 ];

--- a/resources/views/layouts/_alerts.blade.php
+++ b/resources/views/layouts/_alerts.blade.php
@@ -2,11 +2,11 @@
     <div class="w-full text-white p-4 bg-red-500" x-data="{}">
         <div class="flex items-center justify-between container mx-auto px-4">
             {!! session()->pull('error') !!}
-            <button 
-                type="button" 
+            <button
+                type="button"
                 class="text-xl"
                 data-dismiss="alert"
-                aria-hidden="true" 
+                aria-hidden="true"
                 @click="$root.remove()"
             >
                 &times;
@@ -19,10 +19,10 @@
     <div class="w-full text-white bg-lio-500 p-4" x-data="{}">
         <div class="flex items-center justify-between container mx-auto px-4">
             {!! session()->pull('success') !!}
-            <button 
-                type="button" 
+            <button
+                type="button"
                 class="text-xl"
-                data-dismiss="alert" 
+                data-dismiss="alert"
                 aria-hidden="true"
                 @click="$root.remove()"
             >

--- a/resources/views/users/settings/api_tokens.blade.php
+++ b/resources/views/users/settings/api_tokens.blade.php
@@ -14,12 +14,13 @@
 
             <ul class="space-y-3">
                 @foreach(Auth::user()->tokens as $token)
-                    <li>
-                        <span class="block font-bold">{{ $token->name }}</span>
-                        <time datetime="{{ $token->created_at }}" class="block mb-2 text-sm w-full text-gray-700">
-                            {{ $token->created_at->diffForHumans() }}
-                        </time>
-                        <span class="inline-block p-2 bg-gray-200 rounded text-gray-800 max-w-full truncate">{{ $token->token }}</span>
+                    <li class="md:flex justify-between md:space-x-2">
+                        <div>
+                            <span class="block font-bold">{{ $token->name }}</span>
+                            <time datetime="{{ $token->created_at }}" class="block mb-2 text-sm w-full text-gray-700">
+                                {{ $token->created_at->diffForHumans() }}
+                            </time>
+                        </div>
                         <x-buk-form method="DELETE" :action="route('settings.api-tokens.delete')">
                             <input type="hidden" name="id" value="{{ $token->getKey() }}">
                             <x-buttons.danger-button>

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Jobs\CreateApiToken;
 use App\Models\User;
 use Database\Factories\UserFactory;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -139,7 +140,8 @@ test('users can generate API tokens', function () {
         ->submitForm('Generate New Token', [
             'name' => 'My API Token',
         ])
-        ->seePageIs('/settings');
+        ->seePageIs('/settings')
+        ->see('API token created! Please copy the following token as it will not be shown again: ');
 
     expect($user->refresh()->tokens)->toHaveCount(1);
 });
@@ -154,7 +156,8 @@ test('users can delete API tokens', function () {
         ->submitForm('Delete Token', [
             'id' => $token->accessToken->getKey(),
         ])
-        ->seePageIs('/settings');
+        ->seePageIs('/settings')
+        ->see('API token successfully removed.');
 
     expect($user->refresh()->tokens)->toBeEmpty();
 });

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Jobs\CreateApiToken;
 use App\Models\User;
 use Database\Factories\UserFactory;
 use Illuminate\Foundation\Testing\DatabaseMigrations;


### PR DESCRIPTION
So, as pointed out, the tokens displayed for API are actually hashes and as such, useless to show the user.

Now instead, we use the session success feature to show the user their API token once when generated, asking them to copy it. The UI has been updated to remove the hashed tokens in the settings page.