### PR TITLE
Convert search to command palette

### DIFF
--- a/resources/js/search.js
+++ b/resources/js/search.js
@@ -4,7 +4,6 @@ const client = algoliasearch(process.env.MIX_ALGOLIA_APP_ID, process.env.MIX_ALG
 
 window.searchConfig = () => {
     return {
-        show: false,
         threads: {
             total: 0,
             formattedTotal: function () {
@@ -19,9 +18,17 @@ window.searchConfig = () => {
             },
             articles: [],
         },
-        search: async function (query) {
+        toggle() {
+            this.searchQuery = '';
+            this.lockScroll = this.searchVisible;
+
+            if (this.searchVisible)
+                this.$nextTick(() => this.$refs.search.focus());
+
+        },
+        search: async function () {
             // If the input is empty, return no results.
-            if (query.length === 0) {
+            if (this.searchQuery.length === 0) {
                 return Promise.resolve({ hits: [] });
             }
 
@@ -29,7 +36,7 @@ window.searchConfig = () => {
             const { results } = await client.multipleQueries([
                 {
                     indexName: process.env.MIX_ALGOLIA_THREADS_INDEX,
-                    query: query,
+                    query: this.searchQuery,
                     params: {
                         hitsPerPage: 5,
                         attributesToSnippet: ['body:10'],
@@ -37,7 +44,7 @@ window.searchConfig = () => {
                 },
                 {
                     indexName: process.env.MIX_ALGOLIA_ARTICLES_INDEX,
-                    query: query,
+                    query: this.searchQuery,
                     params: {
                         hitsPerPage: 5,
                         attributesToSnippet: ['body:10'],
@@ -45,7 +52,6 @@ window.searchConfig = () => {
                 },
             ]);
 
-            this.show = true;
             this.threads.total = results[0].nbHits;
             this.threads.threads = results[0].hits;
             this.articles.total = results[1].nbHits;

--- a/resources/js/search.js
+++ b/resources/js/search.js
@@ -22,9 +22,7 @@ window.searchConfig = () => {
             this.searchQuery = '';
             this.lockScroll = this.searchVisible;
 
-            if (this.searchVisible)
-                this.$nextTick(() => this.$refs.search.focus());
-
+            if (this.searchVisible) this.$nextTick(() => this.$refs.search.focus());
         },
         search: async function () {
             // If the input is empty, return no results.

--- a/resources/views/_partials/_search.blade.php
+++ b/resources/views/_partials/_search.blade.php
@@ -2,7 +2,7 @@
     class="fixed inset-0 z-50 overflow-y-auto p-4 sm:p-6 md:p-20" role="dialog" aria-modal="true">
     <div class="fixed inset-0 bg-gray-700 bg-opacity-50 transition-opacity" aria-hidden="true"></div>
 
-    <div @click.outside="searchVisible = false" @keyup.window.escape="searchVisible = false"
+    <div @click.outside="searchVisible = false"
         class="mx-auto max-w-xl transform overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-black ring-opacity-5 transition-all">
         <div class="relative">
             <label for="search" class="sr-only">Search</label>
@@ -13,11 +13,12 @@
                     d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
                     clip-rule="evenodd" />
             </svg>
-            <input x-model="searchQuery" x-init="$watch('searchQuery', value => search())" x-ref="search" type="text"
-                name="search" id="search"
+            <input x-model="searchQuery" @input.debounce.100ms="search" x-ref="search" type="text" name="search"
+                id="search"
                 class="h-12 w-full border-0 bg-transparent px-11 pr-4 text-gray-800 placeholder-gray-400 focus:ring-0 sm:text-sm"
                 placeholder="Search..." role="combobox" aria-expanded="false" aria-controls="options">
-            <kbd class="absolute top-3.5 right-4 text-xs rounded bg-gray-100 text-gray-500 px-2 py-1">ESC</kbd>
+            <kbd @keyup.window.escape="searchVisible = false" @click="searchVisible = false"
+                class="absolute top-3.5 right-4 text-xs rounded bg-gray-100 text-gray-500 px-2 py-1 cursor-pointer">ESC</kbd>
         </div>
 
         <div x-show="!searchQuery.length" x-cloak
@@ -89,57 +90,3 @@
 
     </div>
 </div>
-
-{{-- <div x-show="show" x-cloak
-            class="search absolute md:origin-top-right md:right-0 md:rounded md:shadow-lg bg-white md:mt-2 z-50">
-            <div class="flex flex-col md:flex-row">
-                <div class="w-full flex-none border-r border-b md:w-1/2">
-                    <div class="flex text-lg font-medium border-b p-4">
-                        <span class="text-gray-900 mr-3">Threads</span>
-
-                        <span class="text-gray-300" x-text="threads.formattedTotal()"></span>
-                    </div>
-
-                    <div class="max-h-72 overflow-y-scroll">
-                        <template x-for="thread in threads.threads">
-                            <a :href="'/forum/'+thread.slug" class="flex flex-col px-4 py-2 hover:bg-lio-100">
-                                <span class="text-black-900 text-lg font-medium break-all"
-                                    x-html="thread._highlightResult.subject.value"></span>
-                                <span class="text-black-900 break-all" x-html="thread._snippetResult.body.value"></span>
-                            </a>
-                        </template>
-                    </div>
-
-                    <span x-show="threads.length === 0" x-cloak class="p-4 text-gray-500 block">
-                        No threads found
-                    </span>
-                </div>
-
-                <div class="w-full flex-none border-b md:w-1/2">
-                    <div class="flex text-lg font-medium border-b p-4">
-                        <span class="text-gray-900 mr-3">Articles</span>
-
-                        <span class="text-gray-300" x-text="articles.formattedTotal()"></span>
-                    </div>
-
-                    <div class="max-h-72 overflow-y-scroll">
-                        <template x-for="article in articles.articles">
-                            <a :href="'/articles/'+article.slug" class="flex flex-col px-4 py-2 hover:bg-lio-100">
-                                <span class="text-black-900 text-lg font-medium break-all"
-                                    x-html="article._highlightResult.title.value"></span>
-                                <span class="text-black-900 break-all"
-                                    x-html="article._snippetResult.body.value"></span>
-                            </a>
-                        </template>
-                    </div>
-
-                    <span x-show="articles.length === 0" x-cloak class="p-4 text-gray-500 block">
-                        No articles found
-                    </span>
-                </div>
-            </div>
-
-            <a href="https://algolia.com" class="flex justify-end px-4 py-2">
-                <img src="{{ asset('images/algolia.svg') }}" class="h-4 mx-4 my-2" />
-            </a>
-        </div> --}}

--- a/resources/views/_partials/_search.blade.php
+++ b/resources/views/_partials/_search.blade.php
@@ -1,23 +1,97 @@
-<div x-data="searchConfig()">
-    <label for="search" class="sr-only">Search</label>
+<div x-data="searchConfig()" x-init="$watch('searchVisible', value => toggle())" x-show="searchVisible" x-cloak
+    class="fixed inset-0 z-50 overflow-y-auto p-4 sm:p-6 md:p-20" role="dialog" aria-modal="true">
+    <div class="fixed inset-0 bg-gray-700 bg-opacity-50 transition-opacity" aria-hidden="true"></div>
 
-    <div class="relative">
-        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <x-heroicon-o-search class="h-5 w-5 text-gray-800"/>
+    <div @click.outside="searchVisible = false" @keyup.window.escape="searchVisible = false"
+        class="mx-auto max-w-xl transform overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-black ring-opacity-5 transition-all">
+        <div class="relative">
+            <label for="search" class="sr-only">Search</label>
+
+            <svg class="pointer-events-none absolute top-3.5 left-4 h-5 w-5 text-gray-400"
+                xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd"
+                    d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
+                    clip-rule="evenodd" />
+            </svg>
+            <input x-model="searchQuery" x-init="$watch('searchQuery', value => search())" x-ref="search" type="text"
+                name="search" id="search"
+                class="h-12 w-full border-0 bg-transparent px-11 pr-4 text-gray-800 placeholder-gray-400 focus:ring-0 sm:text-sm"
+                placeholder="Search..." role="combobox" aria-expanded="false" aria-controls="options">
+            <kbd class="absolute top-3.5 right-4 text-xs rounded bg-gray-100 text-gray-500 px-2 py-1">ESC</kbd>
         </div>
 
-        <input 
-            @click.outside="show = false" 
-            @keyup.escape="show = false"
-            @keyup="search(event.target.value)"
-            type="search" 
-            name="search" 
-            id="search" 
-            class="border-0 border-t border-b block pl-10 border-gray-300 md:border md:rounded w-full" 
-            placeholder="Search for threads and articles..."
-        />
+        <div x-show="!searchQuery.length" x-cloak
+            class="border-t border-gray-100 py-14 px-6 text-center text-sm sm:px-14">
+            <svg class="mx-auto h-6 w-6 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <p class="mt-4 font-semibold text-gray-900">Search for threads and articles</p>
+            <p class="mt-2 text-gray-500">Quickly access threads and articles by running a global search.</p>
+        </div>
 
-        <div x-show="show" x-cloak class="search absolute md:origin-top-right md:right-0 md:rounded md:shadow-lg bg-white md:mt-2 z-50">
+        <ul x-show="searchQuery.length && (threads.total || articles.total)" x-cloak
+            class="max-h-fit scroll-pt-11 scroll-pb-2 space-y-2 overflow-y-auto pb-2" id="options" role="listbox">
+            <li>
+                <h2 class="bg-gray-100 py-2.5 px-4 font-semibold text-gray-900">
+                    Threads <span x-text="threads.formattedTotal()" class="ml-2 text-sm text-gray-500"></span>
+                </h2>
+                <ul class="mt-2 text-sm text-gray-800">
+                    <template x-for="thread in threads.threads">
+                        <li class="cursor-default select-none px-4 py-2 hover:bg-lio-100" :id="`option-${thread.id}`"
+                            role="option" tabindex="-1">
+                            <a :href="'/forum/'+thread.slug" class="flex flex-col">
+                                <span class="text-black-900 font-medium break-all"
+                                    x-html="thread._highlightResult.subject.value"></span>
+                                <span class="text-black-900 break-all" x-html="thread._snippetResult.body.value"></span>
+                            </a>
+                        </li>
+                    </template>
+                </ul>
+            </li>
+            <li>
+                <h2 class="bg-gray-100 py-2.5 px-4 font-semibold text-gray-900">
+                    Articles <span x-text="articles.formattedTotal()" class="ml-2 text-sm text-gray-500"></span>
+                </h2>
+                <ul class="mt-2 text-sm text-gray-800">
+                    <template x-for="article in articles.articles">
+                        <li class="cursor-default select-none px-4 py-2 hover:bg-lio-100" :id="`option-${article.id}`"
+                            role="option" tabindex="-1">
+                            <a :href="'/articles/'+article.slug" class="flex flex-col">
+                                <span class="text-black-900 font-medium break-all"
+                                    x-html="article._highlightResult.title.value"></span>
+                                <span class="text-black-900 break-all"
+                                    x-html="article._snippetResult.body.value"></span>
+                            </a>
+                        </li>
+                    </template>
+                </ul>
+            </li>
+        </ul>
+
+        <div x-show="searchQuery.length && !threads.total && !articles.total" x-cloak
+            class="border-t border-gray-100 py-14 px-6 text-center text-sm sm:px-14">
+            <svg class="mx-auto h-6 w-6 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none"
+                viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <p class="mt-4 font-semibold text-gray-900">No results found</p>
+            <p class="mt-2 text-gray-500">We couldn’t find anything with that term. Please try again.</p>
+        </div>
+
+        <div class="flex flex-wrap justify-end items-center bg-gray-50 py-2.5 px-4 text-xs text-gray-700">
+            <a href="https://algolia.com">
+                <img src="{{ asset('images/algolia.svg') }}" class="h-4" />
+            </a>
+        </div>
+
+    </div>
+</div>
+
+{{-- <div x-show="show" x-cloak
+            class="search absolute md:origin-top-right md:right-0 md:rounded md:shadow-lg bg-white md:mt-2 z-50">
             <div class="flex flex-col md:flex-row">
                 <div class="w-full flex-none border-r border-b md:w-1/2">
                     <div class="flex text-lg font-medium border-b p-4">
@@ -29,7 +103,8 @@
                     <div class="max-h-72 overflow-y-scroll">
                         <template x-for="thread in threads.threads">
                             <a :href="'/forum/'+thread.slug" class="flex flex-col px-4 py-2 hover:bg-lio-100">
-                                <span class="text-black-900 text-lg font-medium break-all" x-html="thread._highlightResult.subject.value"></span>
+                                <span class="text-black-900 text-lg font-medium break-all"
+                                    x-html="thread._highlightResult.subject.value"></span>
                                 <span class="text-black-900 break-all" x-html="thread._snippetResult.body.value"></span>
                             </a>
                         </template>
@@ -50,8 +125,10 @@
                     <div class="max-h-72 overflow-y-scroll">
                         <template x-for="article in articles.articles">
                             <a :href="'/articles/'+article.slug" class="flex flex-col px-4 py-2 hover:bg-lio-100">
-                                <span class="text-black-900 text-lg font-medium break-all" x-html="article._highlightResult.title.value"></span>
-                                <span class="text-black-900 break-all" x-html="article._snippetResult.body.value"></span>
+                                <span class="text-black-900 text-lg font-medium break-all"
+                                    x-html="article._highlightResult.title.value"></span>
+                                <span class="text-black-900 break-all"
+                                    x-html="article._snippetResult.body.value"></span>
                             </a>
                         </template>
                     </div>
@@ -65,6 +142,4 @@
             <a href="https://algolia.com" class="flex justify-end px-4 py-2">
                 <img src="{{ asset('images/algolia.svg') }}" class="h-4 mx-4 my-2" />
             </a>
-        </div>
-    </div>
-</div>
+        </div> --}}

--- a/resources/views/layouts/_nav.blade.php
+++ b/resources/views/layouts/_nav.blade.php
@@ -1,5 +1,5 @@
 <nav class="{{ isset($hasShadow) ? 'shadow mb-1' : '' }}">
-    <div class="container mx-auto text-gray-800 lg:block lg:py-8" x-data="{ nav: false, search: false, community: false, chat: false, settings: false }" @click.outside="nav = false">
+    <div class="container mx-auto text-gray-800 lg:block lg:py-8" x-data="{ nav: false, searchVisible: false, searchQuery: '', community: false, chat: false, settings: false }" @click.outside="nav = false">
         <div class="block bg-white 2xl:-mx-10">
             <div class="lg:px-4 lg:flex">
                 <div class="block lg:flex lg:items-center lg:shrink-0">
@@ -9,7 +9,7 @@
                         </a>
 
                         <div class="flex lg:hidden">
-                            <button @click="search = !search" :class="{ 'text-lio-500': search }">
+                            <button @click="searchVisible = true">
                                 <x-heroicon-o-search class="w-6 h-6 mr-4" />
                             </button>
 
@@ -120,7 +120,10 @@
                 </div>
 
                 <div class="w-full block gap-x-4 lg:flex lg:items-center lg:justify-end">
-                    <div class="lg:block" x-cloak :class="{ 'block': search, 'hidden': !search }" @click.outside="search = false">
+                    <div class="flex items-center">
+                        <button @click="searchVisible = true" @keyup.window.slash="searchVisible = true" class="hover:text-lio-500">
+                            <x-heroicon-o-search class="h-5 w-5 hidden lg:block" />
+                        </button>
                         @include('_partials._search')
                     </div>
 

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -38,7 +38,7 @@
     @livewireStyles
 </head>
 
-<body class="{{ $bodyClass ?? '' }} font-sans bg-white antialiased" x-data="{ activeModal: false }" @keyup.escape="activeModal = false">
+<body class="{{ $bodyClass ?? '' }} font-sans bg-white antialiased" :class="{ 'overflow-hidden': lockScroll }" x-data="{ lockScroll: false, activeModal: false }" @keyup.escape="activeModal = false">
 
 @include('layouts._ads._banner')
 @include('layouts._nav')


### PR DESCRIPTION
Hi Dries. This resolves [#834](https://github.com/laravelio/laravel.io/issues/834)

Fyi, search on mobile is broken on the live version.
I'd ditch the articles/threads snippets and I'd leave only the titles. What do you think about it?

![image](https://user-images.githubusercontent.com/7842657/158037821-6a42f8cc-58df-4214-86b2-5257a1553194.png)

![image](https://user-images.githubusercontent.com/7842657/158037833-cf522875-db0a-4ed3-8387-ccdd2750eafe.png)

![image](https://user-images.githubusercontent.com/7842657/158037860-1c62b341-5f81-4727-8f5d-2a4318e51a28.png)

![image](https://user-images.githubusercontent.com/7842657/158037892-9e0eef87-a2e3-4582-b6d9-31a3f7ac93a5.png)
