### PR TITLE
Add RSS feed for articles

### DIFF
--- a/config/feed.php
+++ b/config/feed.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Article;
 use App\Models\Thread;
 
 return [
@@ -22,6 +23,56 @@ return [
 
             'title' => 'Laravel.io Forum RSS Feed',
             'description' => 'The RSS feed for the Laravel.io forum contains a list of all threads posted by community members.',
+            'language' => 'en-US',
+
+            /*
+             * The image to display for the feed. For Atom feeds, this is displayed as
+             * a banner/logo; for RSS and JSON feeds, it's displayed as an icon.
+             * An empty value omits the image attribute from the feed.
+             */
+            'image' => '',
+
+            /*
+             * The format of the feed. Acceptable values are 'rss', 'atom', or 'json'.
+             */
+            'format' => 'atom',
+
+            /*
+             * The view that will render the feed.
+             */
+            'view' => 'feed::atom',
+
+            /*
+             * The mime type to be used in the <link> tag. Set to an empty string to automatically
+             * determine the correct value.
+             */
+            'type' => '',
+
+            /*
+             * The content type for the feed response. Set to an empty string to automatically
+             * determine the correct value.
+             */
+            'contentType' => '',
+        ],
+
+        'articles' => [
+            /*
+             * Here you can specify which class and method will return
+             * the items that should appear in the feed. For example:
+             * [App\Model::class, 'getAllFeedItems']
+             *
+             * You can also pass an argument to that method. Note that their key must be the name of the parameter:
+             * [App\Model::class, 'getAllFeedItems', 'parameterName' => 'argument']
+             */
+            'items' => [Article::class, 'getFeedItems'],
+
+            /*
+             * The feed will be available on this url.
+             */
+            'url' => '/articles/feed',
+
+            'title' => 'Laravel.io Articles RSS Feed',
+            'description' => 'The RSS feed for Laravel.io articles contains a list of all articles posted by community members.',
             'language' => 'en-US',
 
             /*

--- a/resources/views/articles/overview.blade.php
+++ b/resources/views/articles/overview.blade.php
@@ -183,6 +183,13 @@
                 <div class="mt-6">
                     <x-moderators :moderators="$moderators" />
                 </div>
+
+                <div class="hidden lg:block mt-6">
+                    <x-buttons.dark-cta class="w-full" href="{{ url('/articles/feed') }}">
+                        <x-heroicon-s-rss class="w-6 h-6 mr-2" />
+                        RSS Feed
+                    </x-buttons.dark-cta>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/forum/overview.blade.php
+++ b/resources/views/forum/overview.blade.php
@@ -164,7 +164,7 @@
                 </div>
 
                 <div class="hidden lg:block mt-6">
-                    <x-buttons.dark-cta class="w-full">
+                    <x-buttons.dark-cta class="w-full" href="{{ url('/forum/feed') }}">
                         <x-heroicon-s-rss class="w-6 h-6 mr-2" />
                         RSS Feed
                     </x-buttons.dark-cta>


### PR DESCRIPTION
This PR resolves #654 by adding a new feed for articles and adding a new `RSS Feed` link to the articles overview.

<img width="1263" alt="Screenshot 2022-04-12 at 21 14 05" src="https://user-images.githubusercontent.com/3438564/163045956-ca787534-5b50-4e3e-a88e-efb713abdb4a.png">

As part of this, I also noticed the `RSS Feed` link on the forum was not working as the href was not set so I updated this too.

We already have `@include('feed::links')` in `base.blade.php` so the feed is automatically added to the source of the page.

<img width="1055" alt="Screenshot 2022-04-12 at 21 14 19" src="https://user-images.githubusercontent.com/3438564/163045979-59666827-c7d5-4d96-964f-4b5bdca731c9.png">

Below is an example of the generated feed.

<img width="1197" alt="Screenshot 2022-04-12 at 21 16 29" src="https://user-images.githubusercontent.com/3438564/163046592-5010ec8d-479b-425b-bdc2-ec8429925f7b.png">
