### PR TITLE
Use articles.show route to get correct url and only show published articles

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -338,7 +338,7 @@ final class Article extends Model implements Feedable
             ->title($this->title())
             ->summary($this->excerpt())
             ->updated($this->updatedAt())
-            ->link(route('articles', $this->slug()))
+            ->link(route('articles.show', $this->slug()))
             ->authorName($this->author()->name());
     }
 }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -327,7 +327,8 @@ final class Article extends Model implements Feedable
 
     public static function getFeedItems(): Collection
     {
-        return self::paginate(self::FEED_PAGE_SIZE)
+        return self::published()
+            ->paginate(self::FEED_PAGE_SIZE)
             ->getCollection();
     }
 


### PR DESCRIPTION
I checked the RSS feed and I noticed that the urls of the articles were not pointing to the actual article.
As you can see in the example below, the URL to the article is passed as an URL query.

This is caused by using the wrong route name. When using the `articles.show` route, the URL becomes `https://laravel.io/articles/an-unopinionated-package-to-make-laravel-apps-tenant-aware` which is an actual page.

```xml
<entry>
  <title>
    <![CDATA[ An unopinionated package to make Laravel apps tenant aware ]]>
  </title>
  <link rel="alternate" href="https://laravel.io/articles?an-unopinionated-package-to-make-laravel-apps-tenant-aware"/>
  <id>https://laravel.io/3</id>
...
</entry>
```

In addition, I also saw that non-published articles showed up in the feed, which leads to a 404 page.