### PR TITLE
fix the bug of mention links.

### DIFF
--- a/app/Concerns/HasMentions.php
+++ b/app/Concerns/HasMentions.php
@@ -4,7 +4,9 @@ namespace App\Concerns;
 
 use App\Models\ReplyAble;
 use App\Models\User;
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 
 trait HasMentions
 {
@@ -22,5 +24,22 @@ trait HasMentions
         preg_match_all('/@([a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w))/', $this->body(), $matches);
 
         return User::whereIn('username', $matches[1])->get();
+    }
+
+    public function repositionMention(string $body): string
+    {
+        $body = Str::of($body);
+
+        if (!$body->startsWith('<') || !$body->contains('@')) {
+            return $body->toString();
+        }
+
+        $mentionRegex = '@[a-z\d]*(?:[a-z\d]|-(?=[a-z\d])){0,38}(?!\w)';
+
+        $mentions = $body
+            ->matchAll('/'.$mentionRegex. '/')
+            ->toArray();
+
+        return implode(' ', $mentions) . ' ' . preg_replace('/\s*'.$mentionRegex. '\s*/', '', $body->toString());
     }
 }

--- a/app/Concerns/HasMentions.php
+++ b/app/Concerns/HasMentions.php
@@ -26,7 +26,7 @@ trait HasMentions
         return User::whereIn('username', $matches[1])->get();
     }
 
-    public function repositionMention(string $body): string
+    public function repositionMention(?string $body): string
     {
         $body = Str::of($body);
 

--- a/app/Http/Livewire/EditReply.php
+++ b/app/Http/Livewire/EditReply.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Livewire;
 
+use App\Concerns\HasMentions;
 use App\Http\Requests\UpdateReplyRequest;
 use App\Policies\ReplyPolicy;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -10,6 +11,7 @@ use Livewire\Component;
 class EditReply extends Component
 {
     use AuthorizesRequests;
+    use HasMentions;
 
     public $reply;
 
@@ -24,7 +26,7 @@ class EditReply extends Component
 
     public function updateReply($body)
     {
-        $this->body = $body;
+        $this->body = $this->repositionMention($body);
         $this->authorize(ReplyPolicy::UPDATE, $this->reply);
 
         $this->validate((new UpdateReplyRequest())->rules());

--- a/app/Http/Livewire/Editor.php
+++ b/app/Http/Livewire/Editor.php
@@ -3,12 +3,15 @@
 namespace App\Http\Livewire;
 
 use App\Models\User;
+use App\Concerns\HasMentions;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Str;
 use Livewire\Component;
 
 class Editor extends Component
 {
+    use HasMentions;
+
     public $label;
 
     public $placeholder = 'Write a reply...';
@@ -74,6 +77,7 @@ class Editor extends Component
 
     public function preview(): void
     {
+        $this->body = $this->repositionMention($this->body);
         $this->emit('previewRequested');
     }
 }

--- a/app/Http/Requests/CreateReplyRequest.php
+++ b/app/Http/Requests/CreateReplyRequest.php
@@ -6,9 +6,12 @@ use App\Models\ReplyAble;
 use App\Models\Thread;
 use App\Models\User;
 use App\Rules\HttpImageRule;
+use App\Concerns\HasMentions;
 
 class CreateReplyRequest extends Request
 {
+    use HasMentions;
+
     public function rules()
     {
         return [
@@ -47,6 +50,6 @@ class CreateReplyRequest extends Request
 
     public function body(): string
     {
-        return $this->get('body');
+        return $this->repositionMention($this->get('body'));
     }
 }

--- a/tests/Feature/EditorTest.php
+++ b/tests/Feature/EditorTest.php
@@ -73,3 +73,9 @@ test('no users are returned when query returns no results', function () {
         ->assertDontSee($users->first()->username())
         ->assertDontSee($users->get(1)->username());
 });
+
+test('mention is repositioned in the body which starts with `<` when users click preview button', function (){
+    Livewire::test(Editor::class, ['body' => '<html> @wadakatu'])
+        ->call('preview')
+        ->assertSeeHtml('<p><a href="http://laravel.io.test/user/wadakatu">@wadakatu</a> &lt;html&gt;</p>');
+});


### PR DESCRIPTION
This PR is associated with #866.

The reason why the bug happens is that the body starts with a html tag.
Therefore, I created one method called `repositionMention`.
It verify the body and move the mention at the beginning of the body if the body starts with a html tag.
It executes before either creating, editing, and previewing the reply.

```
// users' input
<html> @wadakatu

// output
@wadakatu <html>
```

I am not sure if this fix is the best.
Please let me know, if there is a better solution to fix this bug.
Thank you.