### PR TITLE
Merge article counts

### DIFF
--- a/resources/views/layouts/_fathom.blade.php
+++ b/resources/views/layouts/_fathom.blade.php
@@ -1,5 +1,5 @@
 @env(['production', 'testing'])
     <!-- Fathom - beautiful, simple website analytics -->
-    <script src="https://boom.laravel.io/script.js" site="UXCUXOED" defer  @if(isset($canonical) && !Str::startsWith($canonical, config('app.url')))data-canonical="false"@endif></script>
+    <script src="https://boom.laravel.io/script.js" site="UXCUXOED" defer @if(isset($canonical) && !Str::startsWith($canonical, config('app.url')))data-canonical="false"@endif></script>
     <!-- / Fathom -->
 @endenv

--- a/resources/views/layouts/_fathom.blade.php
+++ b/resources/views/layouts/_fathom.blade.php
@@ -1,5 +1,5 @@
-@env(['production', 'testing'])
+@production
     <!-- Fathom - beautiful, simple website analytics -->
     <script src="https://boom.laravel.io/script.js" site="UXCUXOED" defer @if(isset($canonical) && !Str::startsWith($canonical, config('app.url')))data-canonical="false"@endif></script>
     <!-- / Fathom -->
-@endenv
+@endproduction

--- a/resources/views/layouts/_fathom.blade.php
+++ b/resources/views/layouts/_fathom.blade.php
@@ -1,5 +1,5 @@
-@production
+@env(['production', 'testing'])
     <!-- Fathom - beautiful, simple website analytics -->
-    <script src="https://boom.laravel.io/script.js" site="UXCUXOED" defer></script>
+    <script src="https://boom.laravel.io/script.js" site="UXCUXOED" defer  @if(isset($canonical) && !Str::startsWith($canonical, config('app.url')))data-canonical="false"@endif></script>
     <!-- / Fathom -->
-@endproduction
+@endenv

--- a/tests/Feature/CanonicalUrlTest.php
+++ b/tests/Feature/CanonicalUrlTest.php
@@ -4,10 +4,18 @@ use App\Models\Article;
 use App\Models\Tag;
 use App\Models\Thread;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\App;
 use Tests\Feature\BrowserKitTestCase;
 
 uses(BrowserKitTestCase::class);
 uses(DatabaseMigrations::class);
+
+function inProduction()
+{
+    App::detectEnvironment(fn () => 'production');
+}
+
+afterEach(fn () => App::detectEnvironment(fn () => 'testing'));
 
 test('pages without a canonical url explicitly set fall back to the current url', function () {
     $this->get('/register')
@@ -58,11 +66,13 @@ test('canonical tracking is turned off when using external url', function () {
 
     $this->get('/articles/my-first-article')
         ->see('data-canonical="false"');
-});
+})->inProduction();
 
 test('canonical tracking is turned on when using external url', function () {
+    App::detectEnvironment(fn () => 'production');
+
     Article::factory()->create(['slug' => 'my-first-article', 'submitted_at' => now(), 'approved_at' => now()]);
 
     $this->get('/articles/my-first-article')
         ->dontSee('data-canonical="false"');
-});
+})->inProduction();

--- a/tests/Feature/CanonicalUrlTest.php
+++ b/tests/Feature/CanonicalUrlTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Article;
 use App\Models\Tag;
 use App\Models\Thread;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -50,4 +51,18 @@ test('query_params_are_always_in_the_same_order', function () {
 test('standard pages always remove query params from canonical url', function () {
     $this->get('?utm_source=twitter&utm_medium=social&utm_term=abc123')
         ->see('<link rel="canonical" href="http://localhost" />');
+});
+
+test('canonical tracking is turned off when using external url', function () {
+    Article::factory()->create(['slug' => 'my-first-article', 'submitted_at' => now(), 'approved_at' => now(), 'original_url' => 'https://example.com/external-path']);
+
+    $this->get('/articles/my-first-article')
+        ->see('data-canonical="false"');
+});
+
+test('canonical tracking is turned on when using external url', function () {
+    Article::factory()->create(['slug' => 'my-first-article', 'submitted_at' => now(), 'approved_at' => now()]);
+
+    $this->get('/articles/my-first-article')
+        ->dontSee('data-canonical="false"');
 });

--- a/tests/Integration/Commands/UpdateArticleViewCountsTest.php
+++ b/tests/Integration/Commands/UpdateArticleViewCountsTest.php
@@ -28,6 +28,46 @@ test('article view counts can be updated', function () {
     expect($article->fresh()->view_count)->toBe(1234);
 });
 
+test('article view counts can be merged with original url', function () {
+    Http::fake(function () {
+        return Http::response([[
+            'pageviews' => 1234,
+        ]]);
+    });
+
+    $article = Article::factory()->create([
+        'title' => 'My First Article',
+        'slug' => 'my-first-article',
+        'original_url' => 'https://example.com/my-first-article',
+        'submitted_at' => now(),
+        'approved_at' => now(),
+    ]);
+
+    (new UpdateArticleViewCounts)->handle();
+
+    expect($article->fresh()->view_count)->toBe(2468);
+});
+
+test('article view counts are not merged when url is invalid', function () {
+    Http::fake(function () {
+        return Http::response([[
+            'pageviews' => 1234,
+        ]]);
+    });
+
+    $article = Article::factory()->create([
+        'title' => 'My First Article',
+        'slug' => 'my-first-article',
+        'original_url' => 'erhwerhwerh',
+        'submitted_at' => now(),
+        'approved_at' => now(),
+    ]);
+
+    (new UpdateArticleViewCounts)->handle();
+
+    expect($article->fresh()->view_count)->toBe(1234);
+});
+
 test('article view counts are not updated if API call fails', function () {
     Http::fake(function () {
         return Http::response('Uh oh', 500);


### PR DESCRIPTION
This PR ensures view counts include both laravel.io URLs and canonical URLs.

It also conditionally sets the canonical tracking in Fathom to ensure views are collected for the correct URL.