### PR TITLE
Send a notification on slow query

### DIFF
--- a/app/Notifications/SlowQueryLogged.php
+++ b/app/Notifications/SlowQueryLogged.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Telegram\TelegramMessage;
+
+class SlowQueryLogged extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private string $query, private float|null $duration, private string $url)
+    {
+    }
+
+    public function via($notifiable)
+    {
+        if (
+            ! empty(config('services.telegram-bot-api.token')) &&
+            ! empty(config('services.telegram-bot-api.channel'))
+        ) {
+            return ['telegram'];
+        }
+
+        return [];
+    }
+
+    public function toTelegram($notifiable)
+    {
+        return TelegramMessage::create()
+            ->to(config('services.telegram-bot-api.channel'))
+            ->content($this->content());
+    }
+
+    private function content(): string
+    {
+        $content = "*Slow query logged!*\n\n";
+        $content .= "```{$this->query}```\n\n";
+        $content .= "Duration: {$this->duration}ms\n";
+        $content .= "URL: {$this->url}";
+
+        return $content;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -60,8 +60,8 @@ class AppServiceProvider extends ServiceProvider
                 new SlowQueryLogged(
                     $event->sql,
                     $event->time,
-                    Request::url()
-                )
+                    Request::url(),
+                ),
             );
         });
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -31,8 +31,8 @@ class AppServiceProvider extends ServiceProvider
                 new SlowQueryLogged(
                     $event->sql,
                     $event->time,
-                    Request::url()
-                )
+                    Request::url(),
+                ),
             );
         });
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -24,17 +24,7 @@ class AppServiceProvider extends ServiceProvider
         $this->bootEloquentMorphs();
         $this->bootMacros();
         $this->bootHorizon();
-
-        DB::whenQueryingForLongerThan(500, function (Connection $connection, QueryExecuted $event) {
-            Notification::send(
-                new AnonymousNotifiable,
-                new SlowQueryLogged(
-                    $event->sql,
-                    $event->time,
-                    Request::url(),
-                ),
-            );
-        });
+        $this->bootSlowQueryLogging();
     }
 
     private function bootEloquentMorphs()
@@ -59,6 +49,20 @@ class AppServiceProvider extends ServiceProvider
 
         Horizon::auth(function ($request) {
             return auth()->check() && auth()->user()->isAdmin();
+        });
+    }
+
+    private function bootSlowQueryLogging()
+    {
+        DB::whenQueryingForLongerThan(500, function (Connection $connection, QueryExecuted $event) {
+            Notification::send(
+                new AnonymousNotifiable,
+                new SlowQueryLogged(
+                    $event->sql,
+                    $event->time,
+                    Request::url()
+                )
+            );
         });
     }
 }


### PR DESCRIPTION
This PR utilises Laravel's [whenQueryingForLongerThan](https://laravel.com/docs/9.x/database#monitoring-cumulative-query-time) functionality to send a Telegram message to admins if a slow query is encountered.

@driesvints do you think we should make the duration parameter of `whenQueryingForLongerThan` configurable or ship this and see how we get on?

<img width="414" alt="image" src="https://user-images.githubusercontent.com/3438564/189219833-3be02171-bbee-42f6-b39e-c5a4969fcbd9.png">
