### PR TITLE
Fix for duplicate notifications

### DIFF
--- a/app/Listeners/NotifyUsersMentionedInReply.php
+++ b/app/Listeners/NotifyUsersMentionedInReply.php
@@ -12,7 +12,7 @@ final class NotifyUsersMentionedInReply
     public function handle(ReplyWasCreated $event): void
     {
         $event->reply->mentionedUsers()->each(function ($user) use ($event) {
-            if (! $user->hasBlocked($event->reply->author())) {
+            if (! $user->hasBlocked($event->reply->author()) && ! $event->reply->replyAble()->participants()->contains($user)) {
                 $user->notify(new MentionNotification($event->reply));
             }
         });

--- a/app/Models/Reply.php
+++ b/app/Models/Reply.php
@@ -155,11 +155,6 @@ final class Reply extends Model implements MentionAble, Spam
         )->withTimestamps();
     }
 
-    public function thread(): BelongsTo
-    {
-        return $this->belongsTo(Thread::class);
-    }
-
     public function scopeIsSolution(Builder $builder): Builder
     {
         return $builder->has('solutionTo');


### PR DESCRIPTION
Added check if a user participates in a thread, if it is the user doesn't receive mention notifications bc the user already getting reply notification. Deleted thread() method from App\Models\reply because it doesn't work since reply has morphtomany relationship with App\Models\Thread

This is a bug fix for [issue#937](https://github.com/laravelio/laravel.io/issues/937)

