### PR TITLE
Prevents spam by blocking links posing as mentions

### DIFF
--- a/app/Http/Requests/CreateReplyRequest.php
+++ b/app/Http/Requests/CreateReplyRequest.php
@@ -6,13 +6,14 @@ use App\Contracts\ReplyAble;
 use App\Models\Thread;
 use App\Models\User;
 use App\Rules\HttpImageRule;
+use App\Rules\InvalidMentionRule;
 
 class CreateReplyRequest extends Request
 {
     public function rules()
     {
         return [
-            'body' => ['required', new HttpImageRule()],
+            'body' => ['required', new HttpImageRule(), new InvalidMentionRule()],
             'replyable_id' => 'required',
             'replyable_type' => 'required|in:'.Thread::TABLE,
         ];

--- a/app/Http/Requests/ThreadRequest.php
+++ b/app/Http/Requests/ThreadRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use App\Rules\DoesNotContainUrlRule;
 use App\Rules\HttpImageRule;
+use App\Rules\InvalidMentionRule;
 
 class ThreadRequest extends Request
 {
@@ -11,7 +12,7 @@ class ThreadRequest extends Request
     {
         return [
             'subject' => ['required', 'max:60', new DoesNotContainUrlRule()],
-            'body' => ['required', new HttpImageRule()],
+            'body' => ['required', new HttpImageRule(), new InvalidMentionRule()],
             'tags' => 'array',
             'tags.*' => 'exists:tags,id',
         ];

--- a/app/Http/Requests/UpdateReplyRequest.php
+++ b/app/Http/Requests/UpdateReplyRequest.php
@@ -3,13 +3,14 @@
 namespace App\Http\Requests;
 
 use App\Rules\HttpImageRule;
+use App\Rules\InvalidMentionRule;
 
 class UpdateReplyRequest extends Request
 {
     public function rules()
     {
         return [
-            'body' => ['required', new HttpImageRule()],
+            'body' => ['required', new HttpImageRule(), new InvalidMentionRule()],
         ];
     }
 

--- a/app/Rules/InvalidMentionRule.php
+++ b/app/Rules/InvalidMentionRule.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+/**
+ * This rule validates links are not diguised as mentions.
+ */
+final class InvalidMentionRule implements Rule
+{
+    public function passes($attribute, $value): bool
+    {
+        return ! preg_match('/\[@.*\]\(http.*\)/', $value);
+    }
+
+    public function message(): string
+    {
+        return 'The :attribute field contains an invalid mention.';
+    }
+}

--- a/tests/Feature/ForumTest.php
+++ b/tests/Feature/ForumTest.php
@@ -335,7 +335,7 @@ test('cannot fake a mention', function () {
         'body' => 'Hey [@joedixon](https://somethingnasty.com)',
         'tags' => [],
     ]);
-    
+
     $response->assertSessionHas('error', 'Something went wrong. Please review the fields below.');
     $response->assertSessionHasErrors(['body' => 'The body field contains an invalid mention.']);
 });

--- a/tests/Feature/ForumTest.php
+++ b/tests/Feature/ForumTest.php
@@ -326,3 +326,16 @@ test('users are not notified when mentioned in and edited thread', function () {
 
     Notification::assertNothingSent();
 });
+
+test('cannot fake a mention', function () {
+    $this->login();
+
+    $response = $this->post('/forum/create-thread', [
+        'subject' => 'How to work with Eloquent?',
+        'body' => 'Hey [@joedixon](https://somethingnasty.com)',
+        'tags' => [],
+    ]);
+    
+    $response->assertSessionHas('error', 'Something went wrong. Please review the fields below.');
+    $response->assertSessionHasErrors(['body' => 'The body field contains an invalid mention.']);
+});

--- a/tests/Feature/ReplyTest.php
+++ b/tests/Feature/ReplyTest.php
@@ -229,7 +229,7 @@ test('cannot fake a mention when creating a reply', function () {
         'replyable_id' => $thread->id,
         'replyable_type' => Thread::TABLE,
     ]);
-    
+
     $response->assertSessionHas('error', 'Something went wrong. Please review the fields below.');
     $response->assertSessionHasErrors(['body' => 'The body field contains an invalid mention.']);
 });

--- a/tests/Unit/Rules/InvalidMentionRuleTest.php
+++ b/tests/Unit/Rules/InvalidMentionRuleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Rules\HttpImageRule;
+use App\Rules\InvalidMentionRule;
+
+it('passes when no invalid mentions are detected', function ($body) {
+    expect((new InvalidMentionRule())->passes('body', $body))->toBeTrue();
+})->with([
+    'Hello, I\'m looking for some help', 
+    'I\'ve seen [this link](https://example.com), is it legit?',
+    "### Help needed!
+    \n
+    Hello @joedixon I am hoping you can help.
+    \n
+    Here is some **bold** and _italic_ text
+    \n
+    > I'm quoting you now!
+    \n
+    `code goes here`
+    \n
+    ```javascript
+    const string = 'more code goes here'
+    ```
+    \n
+    [link](https://example.com)
+    \n
+    ![image](https://example.com/image.png)"
+]);
+
+it('fails when invalid mentions are detected', function ($body) {
+    expect((new InvalidMentionRule())->passes('body', $body))->toBeFalse();
+})->with([
+    '[@driesvints](https://somethingnasty.com)', 
+    'Hey [@joedixon](https://somethingnasty.com), is it legit?',
+    "### Help needed!
+    \n
+    Hello [@joedixon](https://somethingnasty.com) I am hoping you can help.
+    \n
+    Here is some **bold** and _italic_ text
+    \n
+    > I'm quoting you now!
+    \n
+    `code goes here`
+    \n
+    ```javascript
+    const string = 'more code goes here'
+    ```
+    \n
+    [link](https://example.com)
+    \n
+    ![image](https://example.com/image.png)"
+]);

--- a/tests/Unit/Rules/InvalidMentionRuleTest.php
+++ b/tests/Unit/Rules/InvalidMentionRuleTest.php
@@ -1,12 +1,11 @@
 <?php
 
-use App\Rules\HttpImageRule;
 use App\Rules\InvalidMentionRule;
 
 it('passes when no invalid mentions are detected', function ($body) {
     expect((new InvalidMentionRule())->passes('body', $body))->toBeTrue();
 })->with([
-    'Hello, I\'m looking for some help', 
+    'Hello, I\'m looking for some help',
     'I\'ve seen [this link](https://example.com), is it legit?',
     "### Help needed!
     \n
@@ -24,13 +23,13 @@ it('passes when no invalid mentions are detected', function ($body) {
     \n
     [link](https://example.com)
     \n
-    ![image](https://example.com/image.png)"
+    ![image](https://example.com/image.png)",
 ]);
 
 it('fails when invalid mentions are detected', function ($body) {
     expect((new InvalidMentionRule())->passes('body', $body))->toBeFalse();
 })->with([
-    '[@driesvints](https://somethingnasty.com)', 
+    '[@driesvints](https://somethingnasty.com)',
     'Hey [@joedixon](https://somethingnasty.com), is it legit?',
     "### Help needed!
     \n
@@ -48,5 +47,5 @@ it('fails when invalid mentions are detected', function ($body) {
     \n
     [link](https://example.com)
     \n
-    ![image](https://example.com/image.png)"
+    ![image](https://example.com/image.png)",
 ]);


### PR DESCRIPTION
This PR prevents users from submitting spam links which look like mentions.

It does this by validating the input to ensure it doens't contain markdown in the format `[@joedixon](https://somethingnasty.com)`.