### PR TITLE
Upgrades Livewire v3

### DIFF
--- a/app/Livewire/EditReply.php
+++ b/app/Livewire/EditReply.php
@@ -13,7 +13,6 @@ use Livewire\Component;
 class EditReply extends Component
 {
     use AuthorizesRequests;
-    use DispatchesJobs;
 
     public $reply;
 
@@ -33,7 +32,7 @@ class EditReply extends Component
 
         $this->validate((new UpdateReplyRequest())->rules());
 
-        $this->dispatchSync(new UpdateReply($this->reply, Auth::user(), $this->body));
+        dispatch_sync(new UpdateReply($this->reply, Auth::user(), $this->body));
 
         $this->dispatch('replyEdited');
     }

--- a/app/Livewire/EditReply.php
+++ b/app/Livewire/EditReply.php
@@ -6,7 +6,6 @@ use App\Http\Requests\UpdateReplyRequest;
 use App\Jobs\UpdateReply;
 use App\Policies\ReplyPolicy;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 

--- a/app/Livewire/EditReply.php
+++ b/app/Livewire/EditReply.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Http\Requests\UpdateReplyRequest;
 use App\Jobs\UpdateReply;

--- a/app/Livewire/EditReply.php
+++ b/app/Livewire/EditReply.php
@@ -22,8 +22,6 @@ class EditReply extends Component
         return view('livewire.edit-reply');
     }
 
-    protected $listeners = ['submitted' => 'updateReply'];
-
     public function updateReply($body)
     {
         $this->body = $body;

--- a/app/Livewire/EditReply.php
+++ b/app/Livewire/EditReply.php
@@ -35,6 +35,6 @@ class EditReply extends Component
 
         $this->dispatchSync(new UpdateReply($this->reply, Auth::user(), $this->body));
 
-        $this->emit('replyEdited');
+        $this->dispatch('replyEdited');
     }
 }

--- a/app/Livewire/Editor.php
+++ b/app/Livewire/Editor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;

--- a/app/Livewire/Editor.php
+++ b/app/Livewire/Editor.php
@@ -78,6 +78,6 @@ class Editor extends Component
 
     public function preview(): void
     {
-        $this->emit('previewRequested');
+        $this->dispatch('previewRequested');
     }
 }

--- a/app/Livewire/LikeArticle.php
+++ b/app/Livewire/LikeArticle.php
@@ -5,14 +5,11 @@ namespace App\Livewire;
 use App\Jobs\LikeArticle as LikeArticleJob;
 use App\Jobs\UnlikeArticle as UnlikeArticleJob;
 use App\Models\Article;
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 final class LikeArticle extends Component
 {
-    use DispatchesJobs;
-
     public $article;
 
     public $isSidebar = true;
@@ -31,9 +28,9 @@ final class LikeArticle extends Component
         }
 
         if ($this->article->isLikedBy(Auth::user())) {
-            $this->dispatchSync(new UnlikeArticleJob($this->article, Auth::user()));
+            dispatch_sync(new UnlikeArticleJob($this->article, Auth::user()));
         } else {
-            $this->dispatchSync(new LikeArticleJob($this->article, Auth::user()));
+            dispatch_sync(new LikeArticleJob($this->article, Auth::user()));
         }
 
         $this->dispatch('likeToggled');

--- a/app/Livewire/LikeArticle.php
+++ b/app/Livewire/LikeArticle.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Jobs\LikeArticle as LikeArticleJob;
 use App\Jobs\UnlikeArticle as UnlikeArticleJob;

--- a/app/Livewire/LikeArticle.php
+++ b/app/Livewire/LikeArticle.php
@@ -36,7 +36,7 @@ final class LikeArticle extends Component
             $this->dispatchSync(new LikeArticleJob($this->article, Auth::user()));
         }
 
-        $this->emit('likeToggled');
+        $this->dispatch('likeToggled');
     }
 
     public function likeToggled()

--- a/app/Livewire/LikeReply.php
+++ b/app/Livewire/LikeReply.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Jobs\LikeReply as LikeReplyJob;
 use App\Jobs\UnlikeReply as UnlikeReplyJob;

--- a/app/Livewire/LikeReply.php
+++ b/app/Livewire/LikeReply.php
@@ -5,7 +5,6 @@ namespace App\Livewire;
 use App\Jobs\LikeReply as LikeReplyJob;
 use App\Jobs\UnlikeReply as UnlikeReplyJob;
 use App\Models\Reply;
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 

--- a/app/Livewire/LikeReply.php
+++ b/app/Livewire/LikeReply.php
@@ -11,8 +11,6 @@ use Livewire\Component;
 
 final class LikeReply extends Component
 {
-    use DispatchesJobs;
-
     /** @var \App\Models\Reply */
     public $reply;
 
@@ -28,9 +26,9 @@ final class LikeReply extends Component
         }
 
         if ($this->reply->isLikedBy(Auth::user())) {
-            $this->dispatchSync(new UnlikeReplyJob($this->reply, Auth::user()));
+            dispatch_sync(new UnlikeReplyJob($this->reply, Auth::user()));
         } else {
-            $this->dispatchSync(new LikeReplyJob($this->reply, Auth::user()));
+            dispatch_sync(new LikeReplyJob($this->reply, Auth::user()));
         }
     }
 }

--- a/app/Livewire/LikeThread.php
+++ b/app/Livewire/LikeThread.php
@@ -5,7 +5,6 @@ namespace App\Livewire;
 use App\Jobs\LikeThread as LikeThreadJob;
 use App\Jobs\UnlikeThread as UnlikeThreadJob;
 use App\Models\Thread;
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 

--- a/app/Livewire/LikeThread.php
+++ b/app/Livewire/LikeThread.php
@@ -11,8 +11,6 @@ use Livewire\Component;
 
 final class LikeThread extends Component
 {
-    use DispatchesJobs;
-
     /** @var \App\Models\Thread */
     public $thread;
 
@@ -28,9 +26,9 @@ final class LikeThread extends Component
         }
 
         if ($this->thread->isLikedBy(Auth::user())) {
-            $this->dispatchSync(new UnlikeThreadJob($this->thread, Auth::user()));
+            dispatch_sync(new UnlikeThreadJob($this->thread, Auth::user()));
         } else {
-            $this->dispatchSync(new LikeThreadJob($this->thread, Auth::user()));
+            dispatch_sync(new LikeThreadJob($this->thread, Auth::user()));
         }
     }
 }

--- a/app/Livewire/LikeThread.php
+++ b/app/Livewire/LikeThread.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Jobs\LikeThread as LikeThreadJob;
 use App\Jobs\UnlikeThread as UnlikeThreadJob;

--- a/app/Livewire/NotificationIndicator.php
+++ b/app/Livewire/NotificationIndicator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;

--- a/app/Livewire/Notifications.php
+++ b/app/Livewire/Notifications.php
@@ -44,6 +44,6 @@ final class Notifications extends Component
 
         $this->notificationCount--;
 
-        $this->emit('NotificationMarkedAsRead', $this->notificationCount);
+        $this->dispatch('NotificationMarkedAsRead', $this->notificationCount);
     }
 }

--- a/app/Livewire/Notifications.php
+++ b/app/Livewire/Notifications.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire;
+namespace App\Livewire;
 
 use App\Policies\NotificationPolicy;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "laravel/ui": "^4.2",
         "league/commonmark": "^2.2",
         "league/flysystem-aws-s3-v3": "^3.0",
-        "livewire/livewire": "^2.11",
+        "livewire/livewire": "^3.0",
         "ohdearapp/ohdear-php-sdk": "^3.4",
         "predis/predis": "^2.0",
         "ramsey/uuid": "^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fb8cc3db81a9e0a151d8d50ea3197e8",
+    "content-hash": "1733292c04f989adb54d7ae274240dcf",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -4031,33 +4031,34 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v2.12.6",
+            "version": "v3.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "7d3a57b3193299cf1a0639a3935c696f4da2cf92"
+                "reference": "cae998aa9a474dc0de81869ab1536014c7b31a64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/7d3a57b3193299cf1a0639a3935c696f4da2cf92",
-                "reference": "7d3a57b3193299cf1a0639a3935c696f4da2cf92",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/cae998aa9a474dc0de81869ab1536014c7b31a64",
+                "reference": "cae998aa9a474dc0de81869ab1536014c7b31a64",
                 "shasum": ""
             },
             "require": {
-                "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
-                "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-                "illuminate/validation": "^7.0|^8.0|^9.0|^10.0",
+                "illuminate/database": "^10.0",
+                "illuminate/support": "^10.0",
+                "illuminate/validation": "^10.0",
                 "league/mime-type-detection": "^1.9",
-                "php": "^7.2.5|^8.0",
-                "symfony/http-kernel": "^5.0|^6.0"
+                "php": "^8.1",
+                "symfony/http-kernel": "^6.2"
             },
             "require-dev": {
                 "calebporzio/sushi": "^2.1",
-                "laravel/framework": "^7.0|^8.0|^9.0|^10.0",
+                "laravel/framework": "^10.0",
+                "laravel/prompts": "^0.1.6",
                 "mockery/mockery": "^1.3.1",
-                "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
-                "orchestra/testbench-dusk": "^5.2|^6.0|^7.0|^8.0",
-                "phpunit/phpunit": "^8.4|^9.0",
+                "orchestra/testbench": "^8.0",
+                "orchestra/testbench-dusk": "^8.0",
+                "phpunit/phpunit": "^9.0",
                 "psy/psysh": "@stable"
             },
             "type": "library",
@@ -4092,7 +4093,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v2.12.6"
+                "source": "https://github.com/livewire/livewire/tree/v3.0.10"
             },
             "funding": [
                 {
@@ -4100,7 +4101,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-11T04:02:34+00:00"
+            "time": "2023-10-18T11:18:12+00:00"
         },
         {
             "name": "lorisleiva/cron-translator",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
                 "@tailwindcss/forms": "^0.4.0",
                 "@tailwindcss/typography": "^0.5.0",
                 "algoliasearch": "^4.8.4",
-                "alpinejs": "^3.0",
                 "autoprefixer": "^10.4.0",
                 "axios": "^1.6",
                 "choices.js": "^9.0.1",
@@ -316,21 +315,6 @@
                 "tailwindcss": ">=3.0.0 || insiders"
             }
         },
-        "node_modules/@vue/reactivity": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
-            "dev": true,
-            "dependencies": {
-                "@vue/shared": "3.1.5"
-            }
-        },
-        "node_modules/@vue/shared": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
-            "dev": true
-        },
         "node_modules/algoliasearch": {
             "version": "4.19.1",
             "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.19.1.tgz",
@@ -351,15 +335,6 @@
                 "@algolia/requester-common": "4.19.1",
                 "@algolia/requester-node-http": "4.19.1",
                 "@algolia/transporter": "4.19.1"
-            }
-        },
-        "node_modules/alpinejs": {
-            "version": "3.12.3",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.12.3.tgz",
-            "integrity": "sha512-fLz2dfYQ3xCk7Ip8LiIpV2W+9brUyex2TAE7Z0BCvZdUDklJE+n+a8gCgLWzfZ0GzZNZu7HUP8Z0z6Xbm6fsSA==",
-            "dev": true,
-            "dependencies": {
-                "@vue/reactivity": "~3.1.1"
             }
         },
         "node_modules/any-promise": {
@@ -2296,21 +2271,6 @@
                 "postcss-selector-parser": "6.0.10"
             }
         },
-        "@vue/reactivity": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
-            "dev": true,
-            "requires": {
-                "@vue/shared": "3.1.5"
-            }
-        },
-        "@vue/shared": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
-            "dev": true
-        },
         "algoliasearch": {
             "version": "4.19.1",
             "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.19.1.tgz",
@@ -2331,15 +2291,6 @@
                 "@algolia/requester-common": "4.19.1",
                 "@algolia/requester-node-http": "4.19.1",
                 "@algolia/transporter": "4.19.1"
-            }
-        },
-        "alpinejs": {
-            "version": "3.12.3",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.12.3.tgz",
-            "integrity": "sha512-fLz2dfYQ3xCk7Ip8LiIpV2W+9brUyex2TAE7Z0BCvZdUDklJE+n+a8gCgLWzfZ0GzZNZu7HUP8Z0z6Xbm6fsSA==",
-            "dev": true,
-            "requires": {
-                "@vue/reactivity": "~3.1.1"
             }
         },
         "any-promise": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
         "@tailwindcss/forms": "^0.4.0",
         "@tailwindcss/typography": "^0.5.0",
         "algoliasearch": "^4.8.4",
-        "alpinejs": "^3.0",
         "autoprefixer": "^10.4.0",
         "axios": "^1.6",
         "choices.js": "^9.0.1",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,3 @@
-import { Livewire, Alpine } from '../../vendor/livewire/livewire/dist/livewire.esm';
 import hljs from 'highlight.js';
 import Choices from 'choices.js';
 
@@ -8,10 +7,6 @@ import './bootstrap';
 import './nav';
 import './search';
 import './editor';
-
-window.Alpine = Alpine;
-
-Livewire.start();
 
 // Create a multiselect element.
 window.choices = (element) => {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,4 @@
-import Alpine from 'alpinejs';
+import { Livewire, Alpine } from '../../vendor/livewire/livewire/dist/livewire.esm';
 import hljs from 'highlight.js';
 import Choices from 'choices.js';
 
@@ -11,7 +11,7 @@ import './editor';
 
 window.Alpine = Alpine;
 
-Alpine.start();
+Livewire.start();
 
 // Create a multiselect element.
 window.choices = (element) => {

--- a/resources/js/editor.js
+++ b/resources/js/editor.js
@@ -55,8 +55,7 @@ window.editorConfig = (body, hasMentions) => {
 
         // Submits the form enclosing the editor.
         submit: function () {
-            this.$dispatch('submitted', this.body);
-            this.$wire.emitUp('submitted', this.body);
+            this.$dispatch('submitted', { body: this.body });
         },
 
         // Updates the position of the listbox by calculating the caret position and applying an offset.

--- a/resources/views/components/threads/form.blade.php
+++ b/resources/views/components/threads/form.blade.php
@@ -10,7 +10,7 @@
     action="{{ route(...$route) }}"
     :method="$method"
     x-data="{}"
-    @submitted="$event.currentTarget.submit()"
+    @submitted.stop="$event.currentTarget.submit()"
 >
     <div class="bg-gray-100 py-6 px-4 space-y-6 sm:p-6">
         <div>

--- a/resources/views/forum/threads/show.blade.php
+++ b/resources/views/forum/threads/show.blade.php
@@ -73,7 +73,7 @@
                             <form
                                 action="{{ route('replies.store') }}"
                                 method="POST"
-                                @submitted="$event.currentTarget.submit()"
+                                @submitted.stop="$event.currentTarget.submit()"
                             >
                                 @csrf
 

--- a/resources/views/livewire/edit-reply.blade.php
+++ b/resources/views/livewire/edit-reply.blade.php
@@ -9,7 +9,7 @@
     </div>
 
     @can(App\Policies\ReplyPolicy::UPDATE, $reply)
-        <div x-show="edit" @submitted.window="$wire.updateReply($event.detail.body)">
+        <div x-show="edit" @submitted.stop="$wire.updateReply($event.detail.body)">
             <livewire:editor
                 x-cloak
                 :hasShadow="false"

--- a/resources/views/livewire/edit-reply.blade.php
+++ b/resources/views/livewire/edit-reply.blade.php
@@ -9,7 +9,7 @@
     </div>
 
     @can(App\Policies\ReplyPolicy::UPDATE, $reply)
-        <div x-show="edit">
+        <div x-show="edit" @submitted.window="$wire.updateReply($event.detail.body)">
             <livewire:editor
                 x-cloak
                 :hasShadow="false"

--- a/resources/views/livewire/editor.blade.php
+++ b/resources/views/livewire/editor.blade.php
@@ -40,8 +40,8 @@
                     x-model=body
                     required
                     x-ref="editor"
-                    @keydown.cmd.enter="submit($event)"
-                    @keydown.ctrl.enter="submit($event)"
+                    @keydown.cmd.enter="submit"
+                    @keydown.ctrl.enter="submit"
                     @keydown.space="showMentions = false"
                     @keydown.down="highlightNextUser(event)"
                     @keydown.up="highlightPreviousUser(event)"

--- a/resources/views/livewire/editor.blade.php
+++ b/resources/views/livewire/editor.blade.php
@@ -5,7 +5,7 @@
         </span>
     @endif
 
-    <div x-data="editorConfig($wire.entangle('body').defer, {{ $hasMentions }})" class="bg-white rounded-md {{ $hasShadow ? 'shadow-md' : '' }}">
+    <div x-data="editorConfig(@entangle('body'), {{ $hasMentions }})" class="bg-white rounded-md {{ $hasShadow ? 'shadow-md' : '' }}">
         <ul class="flex p-5 gap-x-4">
             <li>
                 <button

--- a/tests/Feature/EditorTest.php
+++ b/tests/Feature/EditorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Http\Livewire\Editor;
+use App\Livewire\Editor;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\DatabaseMigrations;

--- a/tests/Feature/ForumTest.php
+++ b/tests/Feature/ForumTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Http\Livewire\LikeReply;
-use App\Http\Livewire\LikeThread;
+use App\Livewire\LikeReply;
+use App\Livewire\LikeThread;
 use App\Mail\MentionEmail;
 use App\Models\Reply;
 use App\Models\Tag;

--- a/tests/Feature/NavigationTest.php
+++ b/tests/Feature/NavigationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Http\Livewire\NotificationIndicator;
+use App\Livewire\NotificationIndicator;
 use App\Models\Reply;
 use App\Models\Thread;
 use App\Notifications\NewReplyNotification;

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -73,7 +73,7 @@ test('users_can_mark_notifications_as_read', function () {
         ->assertDontSee(new HtmlString(
             "A new reply was added to <a href=\"{$replyAbleRoute}\" class=\"text-lio-700\">\"{$thread->subject()}\"</a>.",
         ))
-        ->assertEmitted('NotificationMarkedAsRead');
+        ->assertDispatched('NotificationMarkedAsRead');
 });
 
 test('a_non_logged_in_user_cannot_access_notifications', function () {

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Http\Livewire\Notifications;
+use App\Livewire\Notifications;
 use App\Models\Reply;
 use App\Models\Thread;
 use App\Notifications\NewReplyNotification;

--- a/tests/Feature/ReplyTest.php
+++ b/tests/Feature/ReplyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Http\Livewire\EditReply;
+use App\Livewire\EditReply;
 use App\Mail\MentionEmail;
 use App\Models\Reply;
 use App\Models\Thread;


### PR DESCRIPTION
This PR upgrades Livewire to v3.

I used the Livewire automated upgrade tool for the most part. However, due to some of the changes with the way events work, some of the functionality of the editor needed adapting.

`emitUp` no longer exists and so it was no longer possible to just pass the `submit` event up to the parent. In the case of a forum thread with a lot of replies, this resulted in all of the replies being updated when a reply was edited. Not ideal.

I've updated this to rely on the event Alpine was already dispatching, listening for this on the parent and stopping propagation of events. It seems to work nicely, but would appreciate an extra set of eyes.

The event is dispatched [here](https://github.com/laravelio/laravel.io/pull/961/files#diff-b80bd4d6372003621d727bb836f302ec5194189c7e642f4260d15eccedbe4c98R58).

It's then caught and the value passed to the `EditReply` Livewire component [here](https://github.com/laravelio/laravel.io/pull/961/files#diff-fc9884b5a8e9a0daf52e210946486692d94bcd3ed0d0daed956e86bd2c9e77c3R12) 