### PR TITLE
fix: community layout

### DIFF
--- a/resources/views/articles/overview.blade.php
+++ b/resources/views/articles/overview.blade.php
@@ -152,8 +152,8 @@
                                     <div class="flex items-center gap-x-5">
                                         <x-avatar :user="$author" class="w-10 h-10" />
 
-                                        <span class="flex flex-col">
-                                            <a href="{{ route('profile', $author->username()) }}" class="hover:underline">
+                                        <span class="flex flex-col flex-1 min-w-0">
+                                            <a href="{{ route('profile', $author->username()) }}" class="truncate hover:underline">
                                                 <span class="text-gray-900 font-medium">
                                                     {{ $author->username() }}
                                                 </span>

--- a/resources/views/forum/overview.blade.php
+++ b/resources/views/forum/overview.blade.php
@@ -129,8 +129,8 @@
                                     <div class="flex items-center gap-x-5">
                                         <x-avatar :user="$member" class="w-10 h-10" />
 
-                                        <span class="flex flex-col">
-                                            <a href="{{ route('profile', $member->username()) }}" class="hover:underline">
+                                        <span class="flex flex-col flex-1 min-w-0">
+                                            <a href="{{ route('profile', $member->username()) }}" class="truncate hover:underline">
                                                 <span class="text-gray-900 font-medium">
                                                     {{ $member->username() }}
                                                 </span>


### PR DESCRIPTION
Apart of truncate I had to add flex-1 and min-w-0 to parent tag to avoid change the size of the avatar.

The same fix on "top authors list". 

closes #1040 