### PR TITLE
Social footer links wrap unexpectedly

### DIFF
--- a/resources/views/layouts/_footer.blade.php
+++ b/resources/views/layouts/_footer.blade.php
@@ -41,12 +41,12 @@
                         </p>
 
                         <div class="flex flex-wrap lg:flex-col lg:flex-no-wrap">
-                            <a href="https://twitter.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6">
+                            <a href="https://twitter.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6 whitespace-nowrap">
                                 <x-si-x class="text-white w-4 h-4 inline mr-3.5"/>
                                 Twitter
                             </a>
 
-                            <a href="https://github.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6">
+                            <a href="https://github.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6 whitespace-nowrap">
                                 <x-icon-github class="text-white w-4 h-4 inline mr-3.5"/>
                                 GitHub
                             </a>

--- a/resources/views/layouts/_footer.blade.php
+++ b/resources/views/layouts/_footer.blade.php
@@ -42,12 +42,12 @@
 
                         <div class="flex flex-wrap lg:flex-col lg:flex-no-wrap">
                             <a href="https://twitter.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6 whitespace-nowrap">
-                                <x-si-x class="text-white w-4 h-4 inline mr-3.5"/>
+                                <x-si-x class="text-white w-4 h-4 inline mr-2"/>
                                 Twitter
                             </a>
 
                             <a href="https://github.com/laravelio" class="w-1/2 text-gray-400 mb-4 hover:text-gray-200 lg:mb-6 whitespace-nowrap">
-                                <x-icon-github class="text-white w-4 h-4 inline mr-3.5"/>
+                                <x-icon-github class="text-white w-4 h-4 inline mr-2"/>
                                 GitHub
                             </a>
                         </div>


### PR DESCRIPTION
I can open an issue if needed, but noticed that the social links in the footer wrap on only the large breakpoint. It is consistently reproducible across Chrome, Safari, and Firefox. This PR fixes that behavior and makes the icon spacing consistent with community links.

#### Example (PR change left, current right):
<img width="1512" alt="image" src="https://github.com/tmayrand/laravel.io/assets/61019450/0625bd18-5231-4fbb-a8d4-6df8eacd309a">

