### PR TITLE
Removes unnecessary markdown component

### DIFF
--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -106,7 +106,7 @@
                         x-init="$nextTick(function () { highlightCode($el); })"
                         class="prose prose-lg text-gray-800 prose-lio"
                     >
-                        <x-buk-markdown>{!! md_to_html($article->body()) !!}</x-buk-markdown>
+                        {!! md_to_html($article->body()) !!}
                     </div>
 
                     @if ($article->isUpdated())


### PR DESCRIPTION
This PR removes the unnecessary `<x-buk-markdown>` component which causes code formatting issues (duplicate formatting).