### PR TITLE
Allow all tests to run in the suite

### DIFF
--- a/tests/Feature/ReplyTest.php
+++ b/tests/Feature/ReplyTest.php
@@ -215,7 +215,7 @@ test('users provided with a UI notification when mentioned in a reply body', fun
     }
 
     $this->assertTrue($tested);
-})->only();
+});
 
 test('users are not notified when mentioned in an edited reply', function () {
     Notification::fake();


### PR DESCRIPTION
In PR https://github.com/laravelio/laravel.io/pull/1072 `->only()` was introduced in the `Feature/ReplyTest.php` test file. https://github.com/laravelio/laravel.io/blob/23272f486d068420e07fcfcb8b38b6427eb78e89/tests/Feature/ReplyTest.php#L218
This means only that particular test runs and others are ignored. This PR fixes that.