### PR TITLE
Speed up tests by using lower bcrypt rounds in testing env #986

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,7 +23,7 @@
         <env name="AUTH_PASSWORD_RESET_TOKEN_TABLE" value="password_resets"/>
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="mysql"/>
-        <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_DATABASE" value="laravelio_testing"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
@@ -32,5 +32,6 @@
         <env name="TELEGRAM_CHANNEL" value="null"/>
         <env name="FATHOM_SITE_ID" value="1234"/>
         <env name="FATHOM_TOKEN" value="5678"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
     </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,7 +23,7 @@
         <env name="AUTH_PASSWORD_RESET_TOKEN_TABLE" value="password_resets"/>
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="mysql"/>
-        <env name="DB_DATABASE" value="laravelio_testing"/>
+        <env name="DB_DATABASE" value="testing"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/tests/Feature/ConfigTest.php
+++ b/tests/Feature/ConfigTest.php
@@ -1,9 +1,0 @@
-<?php
-
-use Tests\TestCase;
-
-uses(TestCase::class);
-
-test('bcrypt hashing rounds reduced for faster test execution', function () {
-    $this->assertEquals(4, config('hashing.bcrypt.rounds'));
-});

--- a/tests/Feature/ConfigTest.php
+++ b/tests/Feature/ConfigTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+test('bcrypt hashing rounds reduced for faster test execution', function () {
+    $this->assertEquals(4, config('hashing.bcrypt.rounds'));
+});


### PR DESCRIPTION
This PR helps #986 

Improve tests speed

**Before:**
![Pasted Graphic](https://github.com/user-attachments/assets/0d7d000f-0974-499d-a8b7-353097987a2c)
![image](https://github.com/user-attachments/assets/142bda7d-3b90-4313-8cc0-f84e3b512b00)
**After:**
![Pasted Graphic 1](https://github.com/user-attachments/assets/b748d75c-c0ed-4bbb-88f1-bf025376ce1a)
![image](https://github.com/user-attachments/assets/6f5229ba-0db4-4432-810e-07c4229bcd23)

About 1/3 faster on my machine