### PR TITLE
Optimize tests: Replace DatabaseMigrations with RefreshDatabase for f…

### DIFF
--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -5,11 +5,11 @@ use App\Models\Reply;
 use App\Models\Thread;
 use App\Models\User;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('requires login', function () {
     $this->get('/admin')

--- a/tests/Feature/ArticleTest.php
+++ b/tests/Feature/ArticleTest.php
@@ -7,7 +7,7 @@ use App\Models\Tag;
 use App\Models\User;
 use App\Notifications\ArticleApprovedNotification;
 use App\Notifications\ArticleSubmitted;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
@@ -15,7 +15,7 @@ use Illuminate\Support\HtmlString;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('users cannot create an article when not logged in', function () {
     $this->get('/articles/create')

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -4,7 +4,7 @@ use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Contracts\Auth\PasswordBroker;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
@@ -12,7 +12,7 @@ use Illuminate\Support\HtmlString;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('users can register', function () {
     Notification::fake();

--- a/tests/Feature/CanonicalUrlTest.php
+++ b/tests/Feature/CanonicalUrlTest.php
@@ -3,13 +3,13 @@
 use App\Models\Article;
 use App\Models\Tag;
 use App\Models\Thread;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\HtmlString;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 function inProduction()
 {

--- a/tests/Feature/EditorTest.php
+++ b/tests/Feature/EditorTest.php
@@ -3,12 +3,12 @@
 use App\Livewire\Editor;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Sequence;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('participants are rendered when mentions are invoked', function () {
     $participants = User::factory()->count(3)->create();

--- a/tests/Feature/ForumTest.php
+++ b/tests/Feature/ForumTest.php
@@ -9,7 +9,7 @@ use App\Models\Thread;
 use App\Models\User;
 use App\Notifications\MentionNotification;
 use App\Notifications\ThreadDeletedNotification;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\HtmlString;
@@ -17,7 +17,7 @@ use Livewire\Livewire;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('users can see a list of latest threads', function () {
     Thread::factory()->create(['subject' => 'The first thread']);

--- a/tests/Feature/HomeTest.php
+++ b/tests/Feature/HomeTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('users can see the homepage', function () {
     $this->get('/')

--- a/tests/Feature/ModeratorTest.php
+++ b/tests/Feature/ModeratorTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use App\Models\Thread;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('moderators can edit any thread', function () {
     $thread = Thread::factory()->create();

--- a/tests/Feature/NavigationTest.php
+++ b/tests/Feature/NavigationTest.php
@@ -4,13 +4,13 @@ use App\Livewire\NotificationIndicator;
 use App\Models\Reply;
 use App\Models\Thread;
 use App\Notifications\NewReplyNotification;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('a user sees the correct number of notifications', function () {
     $userOne = $this->createUser();

--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -4,7 +4,7 @@ use App\Livewire\Notifications;
 use App\Models\Reply;
 use App\Models\Thread;
 use App\Notifications\NewReplyNotification;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
@@ -13,7 +13,7 @@ use Tests\TestCase;
 use function Pest\Laravel\post;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('users_can_see_notifications', function () {
     $userOne = $this->createUser();

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('anyone can see a user profile', function () {
     $this->createUser();

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -2,14 +2,14 @@
 
 use App\Models\User;
 use Database\Factories\UserFactory;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('requires login', function () {
     $this->get('/settings')

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -6,7 +6,7 @@ use App\Models\Subscription;
 use App\Models\Thread;
 use App\Models\User;
 use App\Notifications\NewReplyNotification;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\HtmlString;
@@ -14,7 +14,7 @@ use Illuminate\Support\Str;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 uses(WithFaker::class);
 
 test('users receive notifications for new replies to threads where they are subscribed to', function () {

--- a/tests/Integration/Api/ArticleTest.php
+++ b/tests/Integration/Api/ArticleTest.php
@@ -4,12 +4,12 @@ use App\Events\ArticleWasSubmittedForApproval;
 use App\Models\Article;
 use Database\Factories\ArticleFactory;
 use Database\Factories\TagFactory;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 use Tests\CreatesUsers;
 use Tests\TestCase;
 
-uses(TestCase::class, CreatesUsers::class, DatabaseMigrations::class);
+uses(TestCase::class, CreatesUsers::class, RefreshDatabase::class);
 
 it('can store an article over the API', function (array $body, array $response) {
     Event::fake();

--- a/tests/Integration/Commands/PostArticleToSocialMediaTest.php
+++ b/tests/Integration/Commands/PostArticleToSocialMediaTest.php
@@ -4,14 +4,14 @@ use App\Console\Commands\PostArticleToSocialMedia;
 use App\Models\Article;
 use App\Notifications\PostArticleToBluesky;
 use App\Notifications\PostArticleToTwitter;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Notification::fake();

--- a/tests/Integration/Commands/UpdateArticleViewCountsTest.php
+++ b/tests/Integration/Commands/UpdateArticleViewCountsTest.php
@@ -2,12 +2,12 @@
 
 use App\Console\Commands\UpdateArticleViewCounts;
 use App\Models\Article;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('article view counts can be updated', function () {
     Http::fake(function () {

--- a/tests/Integration/Jobs/BanUserTest.php
+++ b/tests/Integration/Jobs/BanUserTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use App\Jobs\BanUser;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('can ban a user', function () {
     $user = $this->createUser(['banned_at' => null]);

--- a/tests/Integration/Jobs/BlockUserTest.php
+++ b/tests/Integration/Jobs/BlockUserTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use App\Jobs\BlockUser;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('can block a user', function () {
     $blocker = $this->createUser();

--- a/tests/Integration/Jobs/CreateApiTokenTest.php
+++ b/tests/Integration/Jobs/CreateApiTokenTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use App\Jobs\CreateApiToken;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('creates an API token for the given user', function () {
     $user = $this->createUser();

--- a/tests/Integration/Jobs/CreateArticleTest.php
+++ b/tests/Integration/Jobs/CreateArticleTest.php
@@ -3,12 +3,12 @@
 use App\Events\ArticleWasSubmittedForApproval;
 use App\Jobs\CreateArticle;
 use App\Models\Article;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('we can create a draft article', function () {
     $user = $this->createUser();

--- a/tests/Integration/Jobs/CreateReplyTest.php
+++ b/tests/Integration/Jobs/CreateReplyTest.php
@@ -4,13 +4,13 @@ use App\Events\ReplyWasCreated;
 use App\Jobs\CreateReply;
 use App\Models\Reply;
 use App\Models\Thread;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('we can create a reply', function () {
     Event::fake();

--- a/tests/Integration/Jobs/CreateThreadTest.php
+++ b/tests/Integration/Jobs/CreateThreadTest.php
@@ -2,12 +2,12 @@
 
 use App\Jobs\CreateThread;
 use App\Models\Thread;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('we can create a thread', function () {
     $user = $this->createUser();

--- a/tests/Integration/Jobs/DeleteApiTokenTest.php
+++ b/tests/Integration/Jobs/DeleteApiTokenTest.php
@@ -2,11 +2,11 @@
 
 use App\Jobs\DeleteApiToken;
 use Database\Factories\UserFactory;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('deletes the specified API token for the given user', function () {
     $user = $this->createUser();

--- a/tests/Integration/Jobs/DeleteArticleTest.php
+++ b/tests/Integration/Jobs/DeleteArticleTest.php
@@ -2,11 +2,11 @@
 
 use App\Jobs\DeleteArticle;
 use App\Models\Article;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('an article can be deleted', function () {
     $article = Article::factory()->create();

--- a/tests/Integration/Jobs/DeleteRepliesTest.php
+++ b/tests/Integration/Jobs/DeleteRepliesTest.php
@@ -3,11 +3,11 @@
 use App\Jobs\DeleteReply;
 use App\Models\Reply;
 use App\Models\Thread;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('reply authors can force delete their replies', function () {
     $user = $this->createUser();

--- a/tests/Integration/Jobs/DeleteThreadTest.php
+++ b/tests/Integration/Jobs/DeleteThreadTest.php
@@ -4,11 +4,11 @@ use App\Jobs\DeleteThread;
 use App\Models\Like;
 use App\Models\Reply;
 use App\Models\Thread;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('we can delete a thread and its replies', function () {
     $thread = Thread::factory()->create();

--- a/tests/Integration/Jobs/DeleteUserTest.php
+++ b/tests/Integration/Jobs/DeleteUserTest.php
@@ -4,11 +4,11 @@ use App\Jobs\DeleteUser;
 use App\Models\Reply;
 use App\Models\Thread;
 use App\Models\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('we can delete a user with replies', function () {
     $user = User::factory()->create();

--- a/tests/Integration/Jobs/DeleteUserThreadsTest.php
+++ b/tests/Integration/Jobs/DeleteUserThreadsTest.php
@@ -3,11 +3,11 @@
 use App\Jobs\DeleteUserThreads;
 use App\Models\Thread;
 use App\Models\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('we can delete an user threads', function () {
     $user = User::factory()->create();

--- a/tests/Integration/Jobs/GenerateSocialShareImageTest.php
+++ b/tests/Integration/Jobs/GenerateSocialShareImageTest.php
@@ -2,12 +2,12 @@
 
 use App\Jobs\GenerateSocialShareImage;
 use App\Models\Article;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Spatie\Pixelmatch\Pixelmatch;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('social image is generated for articles', function () {
     $article = Article::factory()->create([

--- a/tests/Integration/Jobs/RegisterUserTest.php
+++ b/tests/Integration/Jobs/RegisterUserTest.php
@@ -3,11 +3,11 @@
 use App\Exceptions\CannotCreateUser;
 use App\Jobs\RegisterUser;
 use App\Models\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('we can create a user', function () {
     $this->dispatch(

--- a/tests/Integration/Jobs/SyncArticleImageTest.php
+++ b/tests/Integration/Jobs/SyncArticleImageTest.php
@@ -2,13 +2,13 @@
 
 use App\Jobs\SyncArticleImage;
 use App\Models\Article;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('hero image url and author information is updated for published articles with hero image', function () {
     Config::set('services.unsplash.access_key', 'test');

--- a/tests/Integration/Jobs/UnbanUserTest.php
+++ b/tests/Integration/Jobs/UnbanUserTest.php
@@ -2,11 +2,11 @@
 
 use App\Jobs\UnbanUser;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('can unban a user', function () {
     $user = $this->createUser(['banned_at' => Carbon::yesterday()]);

--- a/tests/Integration/Jobs/UnblockUserTest.php
+++ b/tests/Integration/Jobs/UnblockUserTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use App\Jobs\UnblockUser;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('can unblock a user', function () {
     $unblocker = $this->createUser();

--- a/tests/Integration/Jobs/UpdateArticleTest.php
+++ b/tests/Integration/Jobs/UpdateArticleTest.php
@@ -3,11 +3,11 @@
 use App\Events\ArticleWasSubmittedForApproval;
 use App\Jobs\UpdateArticle;
 use App\Models\Article;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('we can update an article', function () {
     $user = $this->createUser();

--- a/tests/Integration/Jobs/UpdateProfileTest.php
+++ b/tests/Integration/Jobs/UpdateProfileTest.php
@@ -2,12 +2,12 @@
 
 use App\Events\EmailAddressWasChanged;
 use App\Jobs\UpdateProfile;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 test('we can update a user profile', function () {
     $user = $this->createUser();

--- a/tests/Integration/Mail/NewReplyEmailTest.php
+++ b/tests/Integration/Mail/NewReplyEmailTest.php
@@ -4,11 +4,11 @@ use App\Mail\NewReplyEmail;
 use App\Models\Reply;
 use App\Models\Subscription;
 use App\Models\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('contains a note about solutions when the receiver is the thread author', function () {
     $reply = Reply::factory()->create();

--- a/tests/Integration/Models/SubscriptionTest.php
+++ b/tests/Integration/Models/SubscriptionTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use App\Models\Subscription;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('can get a subscription by its uuid', function () {
     $uuid = Subscription::factory()->create()->uuid();

--- a/tests/Integration/Models/ThreadTest.php
+++ b/tests/Integration/Models/ThreadTest.php
@@ -5,12 +5,12 @@ use App\Models\Reply;
 use App\Models\Thread;
 use App\Models\User;
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('can find by slug', function () {
     Thread::factory()->create(['slug' => 'foo']);

--- a/tests/Integration/Models/UserTest.php
+++ b/tests/Integration/Models/UserTest.php
@@ -5,11 +5,11 @@ use App\Models\Article;
 use App\Models\Reply;
 use App\Models\Thread;
 use App\Models\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('can find by username', function () {
     $this->createUser(['username' => 'johndoe']);

--- a/tests/Integration/Queries/SearchUsersTest.php
+++ b/tests/Integration/Queries/SearchUsersTest.php
@@ -2,11 +2,11 @@
 
 use App\Models\User;
 use App\Queries\SearchUsers;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 uses(TestCase::class);
-uses(DatabaseMigrations::class);
+uses(RefreshDatabase::class);
 
 it('can search by name or email or username', function () {
     User::factory()->create(['name' => 'Freek Murze', 'email' => 'freek@freek.com']);


### PR DESCRIPTION
## Summary
Replaces `DatabaseMigrations` with `RefreshDatabase` across all test files for significant performance improvement while maintaining test isolation and reliability.

## Why the Change?

**DatabaseMigrations** was very slow because:
- Runs `php artisan migrate:fresh --seed` for every single test
- Tears down and rebuilds database schema for each individual test 
- Massive I/O overhead with no reuse

**RefreshDatabase** is faster because:
- Sets up database schema **once** at start
- Uses transactions that auto-rollback after each test
- Laravel's recommended approach for testing

## Safety ✅
- All integration tests still pass
- Same test isolation guarantees
- No breaking changes
- Follows Laravel best practices