### PR TITLE
Set "/" as the URL for the logo in the admin panel

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -70,6 +70,7 @@ class AdminPanelProvider extends PanelProvider
                     ->openUrlInNewTab(),
             ])
             ->brandLogo(asset('images/laravelio-logo.svg'))
+            ->homeUrl('/')
             ->unsavedChangesAlerts()
             ->globalSearch(false)
             ->topNavigation()


### PR DESCRIPTION
[Ah one thing I notice now in production: a link to get back to the main website in the nav somewhere would be great.](https://github.com/laravelio/laravel.io/pull/1344#issuecomment-3312532911)

We already have the `Dashboard` link that takes us to _/admin_, so I think it's a good idea and makes sense to let the logo take us to main website